### PR TITLE
Add orbital rail bridge for T-Oscillator letters

### DIFF
--- a/app/orbital-mechanics/page.tsx
+++ b/app/orbital-mechanics/page.tsx
@@ -1,0 +1,5 @@
+import OrbitalMechanicsLab from "@/components/OrbitalMechanicsLab";
+
+export default function Page() {
+  return <OrbitalMechanicsLab />;
+}

--- a/app/orbital-rail/page.tsx
+++ b/app/orbital-rail/page.tsx
@@ -1,0 +1,5 @@
+import OrbitalRailBridge from "@/components/OrbitalRailBridge";
+
+export default function Page() {
+  return <OrbitalRailBridge />;
+}

--- a/components/OrbitalMechanicsLab.tsx
+++ b/components/OrbitalMechanicsLab.tsx
@@ -1,0 +1,92 @@
+import { computeOrbit, equations, hohmannTransfer, orbitPresets } from "@/data/orbitalMechanics";
+
+function format(value: number, digits = 2) {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: digits }).format(value);
+}
+
+export default function OrbitalMechanicsLab() {
+  const computed = orbitPresets.map(computeOrbit);
+  const leo = computed[0];
+  const geo = computed[2];
+  const transfer = hohmannTransfer(leo.muKm3S2, leo.rKm, geo.rKm);
+
+  return (
+    <main className="min-h-screen bg-[#07070b] text-[#f5efe2]">
+      <section className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10 sm:px-10 lg:px-12">
+        <nav className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-5 text-sm text-white/60">
+          <a className="font-mono uppercase tracking-[0.35em] text-cyan-200" href="/">Orbital Mechanics</a>
+          <div className="flex flex-wrap items-center gap-3">
+            <a className="transition hover:text-cyan-100" href="/">Home</a>
+            <a className="transition hover:text-cyan-100" href="#equations">Equations</a>
+            <a className="transition hover:text-cyan-100" href="#transfer">Transfer</a>
+          </div>
+        </nav>
+
+        <section className="grid flex-1 items-center gap-10 py-16 lg:grid-cols-[1fr_0.95fr]">
+          <div>
+            <p className="mb-4 inline-flex rounded-full border border-cyan-300/30 bg-cyan-300/10 px-4 py-2 text-sm text-cyan-100">
+              Two-body lab • vis-viva • Hohmann transfer • delta-v budget
+            </p>
+            <h1 className="text-5xl font-black tracking-tight sm:text-7xl">Put the math in orbit.</h1>
+            <p className="mt-6 max-w-2xl text-lg leading-8 text-white/72">
+              A compact orbital mechanics lab for circular and elliptical orbits. The central body supplies μ, the orbit supplies r and a, and the spacecraft pays the delta-v bill. No rocket goblin gets to launch without a budget.
+            </p>
+          </div>
+
+          <div className="relative rounded-[2rem] border border-cyan-200/20 bg-cyan-200/[0.06] p-8 shadow-2xl shadow-cyan-950/40">
+            <div className="absolute left-1/2 top-1/2 h-16 w-16 -translate-x-1/2 -translate-y-1/2 rounded-full bg-cyan-200 shadow-[0_0_60px_rgba(103,232,249,0.65)]" />
+            <div className="mx-auto h-72 w-72 rounded-full border border-dashed border-cyan-100/45" />
+            <div className="absolute left-1/2 top-1/2 h-96 w-56 -translate-x-1/2 -translate-y-1/2 rotate-12 rounded-full border border-fuchsia-200/45" />
+            <div className="absolute left-[61%] top-[27%] h-5 w-5 rounded-full bg-fuchsia-200 shadow-[0_0_30px_rgba(244,114,182,0.75)]" />
+            <div className="mt-7 grid grid-cols-2 gap-3 text-sm text-white/70">
+              <div className="rounded-2xl bg-black/30 p-4"><span className="block text-white/45">LEO speed</span>{format(leo.circularVelocityKmS, 3)} km/s</div>
+              <div className="rounded-2xl bg-black/30 p-4"><span className="block text-white/45">LEO period</span>{format(leo.periodMinutes, 1)} min</div>
+            </div>
+          </div>
+        </section>
+
+        <section id="equations" className="grid gap-5 border-t border-white/10 py-12 md:grid-cols-2">
+          {equations.map((equation) => (
+            <article key={equation.name} className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+              <h2 className="text-xl font-bold text-cyan-100">{equation.name}</h2>
+              <pre className="mt-4 overflow-x-auto rounded-2xl bg-black/40 p-4 text-lg text-fuchsia-100">{equation.formula}</pre>
+              <p className="mt-3 text-white/60">{equation.note}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="border-t border-white/10 py-12">
+          <h2 className="text-3xl font-black">Orbit presets</h2>
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            {computed.map((orbit) => (
+              <article key={orbit.name} className="rounded-3xl border border-cyan-200/15 bg-cyan-200/[0.045] p-5">
+                <h3 className="font-bold text-cyan-100">{orbit.name}</h3>
+                <dl className="mt-4 grid grid-cols-2 gap-3 text-sm text-white/65">
+                  <div><dt className="text-white/40">radius r</dt><dd>{format(orbit.rKm)} km</dd></div>
+                  <div><dt className="text-white/40">semi-major a</dt><dd>{format(orbit.semiMajorAxisKm)} km</dd></div>
+                  <div><dt className="text-white/40">velocity</dt><dd>{format(orbit.circularVelocityKmS, 3)} km/s</dd></div>
+                  <div><dt className="text-white/40">period</dt><dd>{format(orbit.periodMinutes, 1)} min</dd></div>
+                  <div><dt className="text-white/40">energy ε</dt><dd>{format(orbit.specificEnergyKm2S2, 3)} km²/s²</dd></div>
+                  <div><dt className="text-white/40">h</dt><dd>{format(orbit.specificAngularMomentumKm2S, 1)} km²/s</dd></div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="transfer" className="rounded-[2rem] border border-fuchsia-200/20 bg-fuchsia-200/[0.06] p-7 mb-10">
+          <h2 className="text-3xl font-black">Hohmann transfer: LEO → GEO</h2>
+          <p className="mt-3 max-w-3xl text-white/65">
+            A Hohmann transfer uses an elliptical transfer orbit tangent to both circular orbits. It is slow, elegant, and cheap-ish: the station wagon of orbital transfers, but with scarier math and fewer cupholders.
+          </p>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-2xl bg-black/30 p-4"><span className="block text-white/45">Δv₁</span>{format(transfer.deltaV1, 3)} km/s</div>
+            <div className="rounded-2xl bg-black/30 p-4"><span className="block text-white/45">Δv₂</span>{format(transfer.deltaV2, 3)} km/s</div>
+            <div className="rounded-2xl bg-black/30 p-4"><span className="block text-white/45">Total Δv</span>{format(transfer.totalDeltaV, 3)} km/s</div>
+            <div className="rounded-2xl bg-black/30 p-4"><span className="block text-white/45">Transfer time</span>{format(transfer.transferTimeMinutes, 1)} min</div>
+          </div>
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/components/OrbitalRailBridge.tsx
+++ b/components/OrbitalRailBridge.tsx
@@ -1,0 +1,106 @@
+import { orbitalRailConstants, orbitalRailEquations, orbitalRailLetters } from "@/data/orbitalRail";
+
+function fmt(value: number, digits = 3) {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: digits }).format(value);
+}
+
+export default function OrbitalRailBridge() {
+  const viewBoxSize = 520;
+  const center = viewBoxSize / 2;
+  const scale = 1.45;
+  const tLetter = orbitalRailLetters.find((item) => item.letter === "T");
+
+  return (
+    <main className="min-h-screen bg-[#07070b] text-[#f5efe2]">
+      <section className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10 sm:px-10 lg:px-12">
+        <nav className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-5 text-sm text-white/60">
+          <a className="font-mono uppercase tracking-[0.35em] text-cyan-200" href="/orbital-mechanics">Orbital Rail</a>
+          <div className="flex flex-wrap items-center gap-3">
+            <a className="transition hover:text-cyan-100" href="/">Home</a>
+            <a className="transition hover:text-cyan-100" href="/orbital-mechanics">Orbital Mechanics</a>
+            <a className="transition hover:text-cyan-100" href="#ensemble">Ensemble</a>
+          </div>
+        </nav>
+
+        <section className="grid flex-1 items-center gap-10 py-16 lg:grid-cols-[0.95fr_1.05fr]">
+          <div>
+            <p className="mb-4 inline-flex rounded-full border border-fuchsia-300/30 bg-fuchsia-300/10 px-4 py-2 text-sm text-fuchsia-100">
+              T as attractor • letters as satellites • mirror chords
+            </p>
+            <h1 className="text-5xl font-black tracking-tight sm:text-7xl">Make the alphabet orbit T.</h1>
+            <p className="mt-6 max-w-2xl text-lg leading-8 text-white/72">
+              This bridge maps the T-Oscillator glyph rail into orbital mechanics. Letters become bodies, T is the central attractor, mirror pairs become chords, and the ensemble gets a Boltzmann weight. Tiny alphabet planets, very serious goblin physics.
+            </p>
+            <div className="mt-7 grid max-w-xl grid-cols-2 gap-3 text-sm text-white/70">
+              <div className="rounded-2xl bg-white/[0.05] p-4"><span className="block text-white/40">Z</span>{fmt(orbitalRailConstants.partitionZ)}</div>
+              <div className="rounded-2xl bg-white/[0.05] p-4"><span className="block text-white/40">Entropy</span>{fmt(orbitalRailConstants.entropy)}</div>
+            </div>
+          </div>
+
+          <div className="rounded-[2rem] border border-cyan-200/20 bg-cyan-200/[0.06] p-5 shadow-2xl shadow-cyan-950/40">
+            <svg viewBox={`0 0 ${viewBoxSize} ${viewBoxSize}`} className="h-[520px] w-full" role="img" aria-label="Letters orbiting T">
+              <circle cx={center} cy={center} r="34" className="fill-cyan-200 drop-shadow-[0_0_24px_rgba(103,232,249,0.85)]" />
+              <text x={center} y={center + 11} textAnchor="middle" className="fill-black text-3xl font-black">T</text>
+              {[72, 108, 144, 180, 216].map((radius) => (
+                <circle key={radius} cx={center} cy={center} r={radius} className="fill-none stroke-white/10" />
+              ))}
+              {orbitalRailLetters.filter((item) => item.index < 27 - item.index).map((item) => {
+                const mirror = orbitalRailLetters.find((candidate) => candidate.letter === item.mirror);
+                if (!mirror) return null;
+                return (
+                  <line
+                    key={`${item.letter}-${mirror.letter}`}
+                    x1={center + item.x * scale}
+                    y1={center + item.y * scale}
+                    x2={center + mirror.x * scale}
+                    y2={center + mirror.y * scale}
+                    className="stroke-fuchsia-200/15"
+                  />
+                );
+              })}
+              {orbitalRailLetters.map((item) => {
+                const isT = item.letter === "T";
+                const x = center + item.x * scale;
+                const y = center + item.y * scale;
+                const size = isT ? 30 : 18;
+                return (
+                  <g key={item.letter}>
+                    <circle cx={x} cy={y} r={isT ? 18 : 11} className={isT ? "fill-cyan-100" : "fill-fuchsia-200/80"} />
+                    <text x={x} y={y + size / 3} textAnchor="middle" className={isT ? "fill-black text-2xl font-black" : "fill-black text-sm font-black"}>{item.letter}</text>
+                  </g>
+                );
+              })}
+            </svg>
+          </div>
+        </section>
+
+        <section className="grid gap-5 border-t border-white/10 py-12 md:grid-cols-2">
+          {orbitalRailEquations.map((equation) => (
+            <article key={equation.name} className="rounded-3xl border border-white/10 bg-white/[0.04] p-6">
+              <h2 className="text-xl font-bold text-cyan-100">{equation.name}</h2>
+              <pre className="mt-4 overflow-x-auto rounded-2xl bg-black/40 p-4 text-lg text-fuchsia-100">{equation.formula}</pre>
+              <p className="mt-3 text-white/60">{equation.note}</p>
+            </article>
+          ))}
+        </section>
+
+        <section id="ensemble" className="border-t border-white/10 py-12">
+          <h2 className="text-3xl font-black">Letter ensemble</h2>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {orbitalRailLetters.map((item) => (
+              <article key={item.letter} className={`rounded-3xl border p-4 ${item.letter === "T" ? "border-cyan-200/50 bg-cyan-200/[0.12]" : "border-white/10 bg-white/[0.035]"}`}>
+                <h3 className="text-xl font-black text-cyan-100">{item.letter} <span className="text-sm text-white/35">↔ {item.mirror}</span></h3>
+                <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-white/60">
+                  <div><dt className="text-white/35">r</dt><dd>{fmt(item.radius, 1)}</dd></div>
+                  <div><dt className="text-white/35">θ</dt><dd>{fmt(item.phaseDeg, 1)}°</dd></div>
+                  <div><dt className="text-white/35">n</dt><dd>{fmt(item.meanMotion, 6)}</dd></div>
+                  <div><dt className="text-white/35">p</dt><dd>{fmt(item.probability, 4)}</dd></div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/data/orbitalMechanics.ts
+++ b/data/orbitalMechanics.ts
@@ -1,0 +1,76 @@
+export type OrbitPreset = {
+  name: string;
+  body: string;
+  muKm3S2: number;
+  radiusKm: number;
+  altitudeKm: number;
+  eccentricity: number;
+};
+
+export type OrbitComputed = OrbitPreset & {
+  rKm: number;
+  semiMajorAxisKm: number;
+  periapsisKm: number;
+  apoapsisKm: number;
+  circularVelocityKmS: number;
+  periodMinutes: number;
+  specificEnergyKm2S2: number;
+  specificAngularMomentumKm2S: number;
+};
+
+export const orbitPresets: OrbitPreset[] = [
+  { name: "Low Earth reference", body: "Earth", muKm3S2: 398600.4418, radiusKm: 6378.137, altitudeKm: 400, eccentricity: 0 },
+  { name: "GPS-like MEO", body: "Earth", muKm3S2: 398600.4418, radiusKm: 6378.137, altitudeKm: 20200, eccentricity: 0.01 },
+  { name: "Geostationary belt", body: "Earth", muKm3S2: 398600.4418, radiusKm: 6378.137, altitudeKm: 35786, eccentricity: 0 },
+  { name: "Lunar low orbit", body: "Moon", muKm3S2: 4902.8001, radiusKm: 1737.4, altitudeKm: 100, eccentricity: 0 }
+];
+
+export function computeOrbit(preset: OrbitPreset): OrbitComputed {
+  const rKm = preset.radiusKm + preset.altitudeKm;
+  const semiMajorAxisKm = rKm / (1 - preset.eccentricity);
+  const periapsisKm = semiMajorAxisKm * (1 - preset.eccentricity);
+  const apoapsisKm = semiMajorAxisKm * (1 + preset.eccentricity);
+  const circularVelocityKmS = Math.sqrt(preset.muKm3S2 / rKm);
+  const periodMinutes = (2 * Math.PI * Math.sqrt(Math.pow(semiMajorAxisKm, 3) / preset.muKm3S2)) / 60;
+  const specificEnergyKm2S2 = -preset.muKm3S2 / (2 * semiMajorAxisKm);
+  const specificAngularMomentumKm2S = Math.sqrt(preset.muKm3S2 * semiMajorAxisKm * (1 - preset.eccentricity ** 2));
+
+  return {
+    ...preset,
+    rKm,
+    semiMajorAxisKm,
+    periapsisKm,
+    apoapsisKm,
+    circularVelocityKmS,
+    periodMinutes,
+    specificEnergyKm2S2,
+    specificAngularMomentumKm2S
+  };
+}
+
+export function hohmannTransfer(muKm3S2: number, r1Km: number, r2Km: number) {
+  const aTransferKm = (r1Km + r2Km) / 2;
+  const v1 = Math.sqrt(muKm3S2 / r1Km);
+  const v2 = Math.sqrt(muKm3S2 / r2Km);
+  const vTransferPeriapsis = Math.sqrt(muKm3S2 * (2 / r1Km - 1 / aTransferKm));
+  const vTransferApoapsis = Math.sqrt(muKm3S2 * (2 / r2Km - 1 / aTransferKm));
+  const deltaV1 = Math.abs(vTransferPeriapsis - v1);
+  const deltaV2 = Math.abs(v2 - vTransferApoapsis);
+  const transferTimeMinutes = Math.PI * Math.sqrt(Math.pow(aTransferKm, 3) / muKm3S2) / 60;
+
+  return {
+    aTransferKm,
+    deltaV1,
+    deltaV2,
+    totalDeltaV: deltaV1 + deltaV2,
+    transferTimeMinutes
+  };
+}
+
+export const equations = [
+  { name: "Vis-viva", formula: "v² = μ(2/r - 1/a)", note: "Velocity anywhere on a Keplerian orbit." },
+  { name: "Kepler period", formula: "T = 2π√(a³/μ)", note: "Orbital period from semi-major axis." },
+  { name: "Specific energy", formula: "ε = v²/2 - μ/r = -μ/(2a)", note: "Bound ellipses have negative energy." },
+  { name: "Conic radius", formula: "r(ν)=a(1-e²)/(1+e cosν)", note: "Radius by true anomaly ν." },
+  { name: "Angular momentum", formula: "h = |r × v| = √(μa(1-e²))", note: "Constant for two-body motion." }
+];

--- a/data/orbitalRail.ts
+++ b/data/orbitalRail.ts
@@ -1,0 +1,74 @@
+export type OrbitalRailLetter = {
+  letter: string;
+  index: number;
+  distanceFromT: number;
+  mirror: string;
+  radius: number;
+  phaseDeg: number;
+  meanMotion: number;
+  energy: number;
+  boltzWeight: number;
+  probability: number;
+  x: number;
+  y: number;
+};
+
+const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+const mu = 1;
+const r0 = 72;
+const deltaR = 9;
+const beta = 1.35;
+
+function rawLetter(letter: string, idx: number) {
+  const index = idx + 1;
+  const distanceFromT = index - 20;
+  const radius = r0 + deltaR * Math.abs(distanceFromT);
+  const phaseRad = (2 * Math.PI * (index - 20)) / 26;
+  const phaseDeg = (phaseRad * 180) / Math.PI;
+  const meanMotion = Math.sqrt(mu / Math.pow(radius, 3));
+  const mirrorIndex = 27 - index;
+  const mirrorPenalty = Math.abs(mirrorIndex - 20) / 100;
+  const railPenalty = Math.abs(distanceFromT) / 90;
+  const energy = -mu / (2 * radius) + railPenalty + mirrorPenalty;
+  const boltzWeight = Math.exp(-beta * energy);
+  return {
+    letter,
+    index,
+    distanceFromT,
+    mirror: alphabet[mirrorIndex - 1],
+    radius,
+    phaseDeg,
+    meanMotion,
+    energy,
+    boltzWeight,
+    x: radius * Math.cos(phaseRad),
+    y: radius * Math.sin(phaseRad)
+  };
+}
+
+const raw = alphabet.map(rawLetter);
+const partitionZ = raw.reduce((sum, item) => sum + item.boltzWeight, 0);
+
+export const orbitalRailLetters: OrbitalRailLetter[] = raw.map((item) => ({
+  ...item,
+  probability: item.boltzWeight / partitionZ
+}));
+
+export const orbitalRailConstants = {
+  mu,
+  r0,
+  deltaR,
+  beta,
+  partitionZ,
+  entropy: -orbitalRailLetters.reduce((sum, item) => sum + item.probability * Math.log(item.probability), 0),
+  centralLetter: "T",
+  centralIndex: 20
+};
+
+export const orbitalRailEquations = [
+  { name: "Letter radius", formula: "r_i = r₀ + Δr |i - 20|", note: "T has index 20, so T is the central attractor." },
+  { name: "Orbital phase", formula: "θ_i(t)=θ_i0+n_i t", note: "Letters advance by mean motion." },
+  { name: "Mean motion", formula: "n_i = √(μ/r_i³)", note: "Outer letters drift slower." },
+  { name: "Mirror pair", formula: "M(i)=27-i", note: "A↔Z, B↔Y, and the rail folds around the alphabet." },
+  { name: "Stat weight", formula: "p_i ∝ exp(-βE_i)", note: "Lower-energy letters dominate the rail ensemble." }
+];


### PR DESCRIPTION
Adds an `/orbital-rail` route that bridges the T-Oscillator glyph system to orbital mechanics.

Includes:
- `data/orbitalRail.ts`: maps A-Z letters into radii, phases, mirror-pairs, mean motion, energy, Boltzmann weights, and probabilities.
- `components/OrbitalRailBridge.tsx`: visualization with T as attractor, letter satellites, orbit rings, mirror chords, and ensemble table.
- `app/orbital-rail/page.tsx`: route.

Core mapping:
```txt
r_i = r0 + Δr |i - 20|
θ_i(t)=θ_i0+n_i t
n_i = √(μ/r_i^3)
M(i)=27-i
p_i ∝ exp(-βE_i)
```

This keeps the typography system and orbital mechanics system in one mathematical skeleton instead of creating two separate goblin huts.

Closes #6.