### PR TITLE
Add ZF set theory math network connector

### DIFF
--- a/app/math-network/zf/page.tsx
+++ b/app/math-network/zf/page.tsx
@@ -1,0 +1,5 @@
+import { ZFSetTheoryConnector } from "@/components/ZFSetTheoryConnector";
+
+export default function ZFMathNetworkPage() {
+  return <ZFSetTheoryConnector />;
+}

--- a/components/ZFSetTheoryConnector.tsx
+++ b/components/ZFSetTheoryConnector.tsx
@@ -1,0 +1,156 @@
+import { zfEdges, zfNetworkHealth, zfNodes, zfPredicates } from "@/data/zfSetTheory";
+
+const kindClasses = {
+  axiom: "border-cyan-300/40 bg-cyan-950/40 text-cyan-100",
+  operator: "border-violet-300/40 bg-violet-950/40 text-violet-100",
+  relation: "border-emerald-300/40 bg-emerald-950/40 text-emerald-100",
+  extension: "border-amber-300/40 bg-amber-950/40 text-amber-100",
+};
+
+const edgeClasses = {
+  defines: "text-cyan-200",
+  requires: "text-fuchsia-200",
+  constructs: "text-emerald-200",
+  guards: "text-rose-200",
+  extends: "text-amber-200",
+};
+
+export function ZFSetTheoryConnector() {
+  const health = zfNetworkHealth();
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-10 text-slate-100">
+      <section className="mx-auto flex max-w-6xl flex-col gap-8">
+        <header className="rounded-3xl border border-slate-700 bg-slate-900/80 p-6 shadow-2xl">
+          <p className="text-sm uppercase tracking-[0.35em] text-cyan-300">
+            Math Network Connector
+          </p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight">
+            Zermelo-Fraenkel Set Theory
+          </h1>
+          <p className="mt-4 max-w-3xl text-slate-300">
+            A symbolic network model of ZF set theory. Nodes represent axioms,
+            relations, and extension points; edges represent logical dependency,
+            construction flow, and guard constraints. The network is formal
+            scaffolding, not metaphysical fog juice.
+          </p>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-4">
+          <Metric label="axioms" value={health.axiomCount} />
+          <Metric label="relations" value={health.relationCount} />
+          <Metric label="edges" value={health.edgeCount} />
+          <Metric label="mean axiom weight" value={health.meanAxiomWeight} />
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-3xl border border-slate-700 bg-slate-900/70 p-4">
+            <h2 className="mb-4 text-xl font-semibold">Network map</h2>
+            <svg viewBox="0 0 740 470" className="h-[470px] w-full rounded-2xl bg-slate-950">
+              <defs>
+                <marker id="arrow" markerHeight="8" markerWidth="8" orient="auto" refX="7" refY="4">
+                  <path d="M0,0 L8,4 L0,8 Z" fill="rgb(148 163 184)" />
+                </marker>
+              </defs>
+              {zfEdges.map((edge) => {
+                const from = zfNodes.find((node) => node.id === edge.from);
+                const to = zfNodes.find((node) => node.id === edge.to);
+                if (!from || !to) return null;
+                return (
+                  <g key={edge.id}>
+                    <line
+                      x1={from.x}
+                      y1={from.y}
+                      x2={to.x}
+                      y2={to.y}
+                      stroke="rgb(71 85 105)"
+                      strokeWidth="2"
+                      markerEnd="url(#arrow)"
+                      opacity="0.75"
+                    />
+                    <text
+                      x={(from.x + to.x) / 2}
+                      y={(from.y + to.y) / 2 - 6}
+                      textAnchor="middle"
+                      className="fill-slate-300 text-[10px]"
+                    >
+                      {edge.label}
+                    </text>
+                  </g>
+                );
+              })}
+              {zfNodes.map((node) => (
+                <g key={node.id}>
+                  <circle
+                    cx={node.x}
+                    cy={node.y}
+                    r={node.kind === "axiom" ? 31 : 25}
+                    className={node.kind === "axiom" ? "fill-cyan-950 stroke-cyan-300" : node.kind === "relation" ? "fill-emerald-950 stroke-emerald-300" : "fill-amber-950 stroke-amber-300"}
+                    strokeWidth="2"
+                  />
+                  <text x={node.x} y={node.y - 4} textAnchor="middle" className="fill-white text-[10px] font-bold">
+                    {node.label.split(" ")[0]}
+                  </text>
+                  <text x={node.x} y={node.y + 10} textAnchor="middle" className="fill-slate-300 text-[9px]">
+                    {node.kind}
+                  </text>
+                </g>
+              ))}
+            </svg>
+          </div>
+
+          <aside className="rounded-3xl border border-slate-700 bg-slate-900/70 p-5">
+            <h2 className="text-xl font-semibold">Core predicates</h2>
+            <div className="mt-4 flex flex-col gap-3">
+              {zfPredicates.map((predicate) => (
+                <code key={predicate} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-cyan-100">
+                  {predicate}
+                </code>
+              ))}
+            </div>
+          </aside>
+        </section>
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {zfNodes.map((node) => (
+            <article key={node.id} className={`rounded-2xl border p-4 ${kindClasses[node.kind]}`}>
+              <div className="flex items-center justify-between gap-3">
+                <h3 className="font-semibold">{node.label}</h3>
+                <span className="rounded-full bg-black/25 px-2 py-1 text-xs uppercase tracking-wide">
+                  {node.kind}
+                </span>
+              </div>
+              <p className="mt-2 text-sm opacity-85">{node.shortName}</p>
+              <code className="mt-3 block rounded-xl bg-black/30 p-3 text-xs">{node.symbol}</code>
+              <p className="mt-3 text-sm leading-6 opacity-90">{node.description}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="rounded-3xl border border-slate-700 bg-slate-900/70 p-5">
+          <h2 className="text-xl font-semibold">Connector edges</h2>
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            {zfEdges.map((edge) => (
+              <div key={edge.id} className="rounded-2xl border border-slate-700 bg-slate-950 p-4">
+                <p className={`text-sm font-semibold uppercase tracking-wide ${edgeClasses[edge.kind]}`}>{edge.kind}</p>
+                <p className="mt-2 text-slate-200">
+                  <span className="font-mono">{edge.from}</span> → <span className="font-mono">{edge.to}</span>
+                </p>
+                <p className="mt-1 text-sm text-slate-400">{edge.label}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </section>
+    </main>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-2xl border border-slate-700 bg-slate-900/70 p-4">
+      <p className="text-sm uppercase tracking-wide text-slate-400">{label}</p>
+      <p className="mt-2 text-3xl font-bold text-cyan-200">{value}</p>
+    </div>
+  );
+}

--- a/components/ZFSetTheoryConnector.tsx
+++ b/components/ZFSetTheoryConnector.tsx
@@ -1,4 +1,11 @@
-import { zfEdges, zfNetworkHealth, zfNodes, zfPredicates } from "@/data/zfSetTheory";
+import {
+  bayesianCoordinateFormula,
+  zfBayesianCoordinateSummary,
+  zfEdges,
+  zfNetworkHealth,
+  zfNodes,
+  zfPredicates,
+} from "@/data/zfSetTheory";
 
 const kindClasses = {
   axiom: "border-cyan-300/40 bg-cyan-950/40 text-cyan-100",
@@ -17,6 +24,7 @@ const edgeClasses = {
 
 export function ZFSetTheoryConnector() {
   const health = zfNetworkHealth();
+  const bayes = zfBayesianCoordinateSummary();
 
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-slate-100">
@@ -31,16 +39,31 @@ export function ZFSetTheoryConnector() {
           <p className="mt-4 max-w-3xl text-slate-300">
             A symbolic network model of ZF set theory. Nodes represent axioms,
             relations, and extension points; edges represent logical dependency,
-            construction flow, and guard constraints. The network is formal
-            scaffolding, not metaphysical fog juice.
+            construction flow, and guard constraints. Bayesian coordinates add a
+            hypothesis/evidence overlay for UI ranking only. They are not truth
+            meters, because that would be a statistics goblin in a fake crown.
           </p>
         </header>
 
         <section className="grid gap-4 md:grid-cols-4">
           <Metric label="axioms" value={health.axiomCount} />
           <Metric label="relations" value={health.relationCount} />
-          <Metric label="edges" value={health.edgeCount} />
-          <Metric label="mean axiom weight" value={health.meanAxiomWeight} />
+          <Metric label="mean posterior" value={health.meanPosterior} />
+          <Metric label="bayes confidence" value={health.meanBayesConfidence} />
+        </section>
+
+        <section className="rounded-3xl border border-slate-700 bg-slate-900/70 p-5">
+          <h2 className="text-xl font-semibold">Bayesian coordinate layer</h2>
+          <p className="mt-2 text-sm text-slate-300">
+            Formula: <code className="rounded bg-slate-950 px-2 py-1 text-cyan-100">{bayesianCoordinateFormula}</code>
+          </p>
+          <div className="mt-4 grid gap-3 md:grid-cols-5">
+            <Metric label="mean prior" value={bayes.meanPrior} />
+            <Metric label="mean likelihood" value={bayes.meanLikelihood} />
+            <Metric label="mean evidence" value={bayes.meanEvidence} />
+            <Metric label="mean posterior" value={bayes.meanPosterior} />
+            <Metric label="mean confidence" value={bayes.meanConfidence} />
+          </div>
         </section>
 
         <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
@@ -84,15 +107,16 @@ export function ZFSetTheoryConnector() {
                   <circle
                     cx={node.x}
                     cy={node.y}
-                    r={node.kind === "axiom" ? 31 : 25}
+                    r={24 + node.bayes.posterior * 10}
                     className={node.kind === "axiom" ? "fill-cyan-950 stroke-cyan-300" : node.kind === "relation" ? "fill-emerald-950 stroke-emerald-300" : "fill-amber-950 stroke-amber-300"}
                     strokeWidth="2"
+                    opacity={0.62 + node.bayes.confidence * 0.35}
                   />
                   <text x={node.x} y={node.y - 4} textAnchor="middle" className="fill-white text-[10px] font-bold">
                     {node.label.split(" ")[0]}
                   </text>
                   <text x={node.x} y={node.y + 10} textAnchor="middle" className="fill-slate-300 text-[9px]">
-                    {node.kind}
+                    P={node.bayes.posterior}
                   </text>
                 </g>
               ))}
@@ -123,6 +147,15 @@ export function ZFSetTheoryConnector() {
               <p className="mt-2 text-sm opacity-85">{node.shortName}</p>
               <code className="mt-3 block rounded-xl bg-black/30 p-3 text-xs">{node.symbol}</code>
               <p className="mt-3 text-sm leading-6 opacity-90">{node.description}</p>
+              <div className="mt-4 grid grid-cols-2 gap-2 text-xs">
+                <BayesPill label="prior" value={node.bayes.prior} />
+                <BayesPill label="likelihood" value={node.bayes.likelihood} />
+                <BayesPill label="evidence" value={node.bayes.evidence} />
+                <BayesPill label="posterior" value={node.bayes.posterior} />
+              </div>
+              <p className="mt-3 rounded-xl bg-black/25 p-2 text-xs opacity-85">
+                Bayesian note: {node.bayes.note}
+              </p>
             </article>
           ))}
         </section>
@@ -151,6 +184,15 @@ function Metric({ label, value }: { label: string; value: number }) {
     <div className="rounded-2xl border border-slate-700 bg-slate-900/70 p-4">
       <p className="text-sm uppercase tracking-wide text-slate-400">{label}</p>
       <p className="mt-2 text-3xl font-bold text-cyan-200">{value}</p>
+    </div>
+  );
+}
+
+function BayesPill({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl bg-black/25 p-2">
+      <p className="uppercase tracking-wide opacity-60">{label}</p>
+      <p className="font-mono text-sm">{value}</p>
     </div>
   );
 }

--- a/data/zfSetTheory.ts
+++ b/data/zfSetTheory.ts
@@ -1,5 +1,14 @@
 export type ZFNodeKind = "axiom" | "operator" | "relation" | "extension";
 
+export type BayesianCoordinate = {
+  prior: number;
+  likelihood: number;
+  evidence: number;
+  posterior: number;
+  confidence: number;
+  note: string;
+};
+
 export type ZFNode = {
   id: string;
   label: string;
@@ -10,6 +19,7 @@ export type ZFNode = {
   x: number;
   y: number;
   weight: number;
+  bayes: BayesianCoordinate;
 };
 
 export type ZFEdgeKind = "defines" | "requires" | "constructs" | "guards" | "extends";
@@ -21,6 +31,10 @@ export type ZFEdge = {
   kind: ZFEdgeKind;
   label: string;
 };
+
+function posterior(prior: number, likelihood: number, evidence: number) {
+  return Number(((likelihood * prior) / evidence).toFixed(3));
+}
 
 export const zfNodes: ZFNode[] = [
   {
@@ -34,6 +48,7 @@ export const zfNodes: ZFNode[] = [
     x: 280,
     y: 70,
     weight: 0.98,
+    bayes: { prior: 0.96, likelihood: 0.98, evidence: 0.97, posterior: posterior(0.96, 0.98, 0.97), confidence: 0.97, note: "identity anchor" },
   },
   {
     id: "empty-set",
@@ -46,6 +61,7 @@ export const zfNodes: ZFNode[] = [
     x: 90,
     y: 170,
     weight: 0.82,
+    bayes: { prior: 0.88, likelihood: 0.91, evidence: 0.93, posterior: posterior(0.88, 0.91, 0.93), confidence: 0.9, note: "base construction" },
   },
   {
     id: "pairing",
@@ -58,6 +74,7 @@ export const zfNodes: ZFNode[] = [
     x: 200,
     y: 210,
     weight: 0.84,
+    bayes: { prior: 0.86, likelihood: 0.89, evidence: 0.92, posterior: posterior(0.86, 0.89, 0.92), confidence: 0.88, note: "finite grouping" },
   },
   {
     id: "union",
@@ -70,6 +87,7 @@ export const zfNodes: ZFNode[] = [
     x: 380,
     y: 210,
     weight: 0.88,
+    bayes: { prior: 0.89, likelihood: 0.9, evidence: 0.91, posterior: posterior(0.89, 0.9, 0.91), confidence: 0.9, note: "layer flattening" },
   },
   {
     id: "power-set",
@@ -82,6 +100,7 @@ export const zfNodes: ZFNode[] = [
     x: 510,
     y: 170,
     weight: 0.92,
+    bayes: { prior: 0.9, likelihood: 0.94, evidence: 0.95, posterior: posterior(0.9, 0.94, 0.95), confidence: 0.92, note: "subset expansion" },
   },
   {
     id: "separation",
@@ -94,6 +113,7 @@ export const zfNodes: ZFNode[] = [
     x: 130,
     y: 350,
     weight: 0.9,
+    bayes: { prior: 0.91, likelihood: 0.92, evidence: 0.94, posterior: posterior(0.91, 0.92, 0.94), confidence: 0.91, note: "bounded filtering" },
   },
   {
     id: "replacement",
@@ -106,6 +126,7 @@ export const zfNodes: ZFNode[] = [
     x: 280,
     y: 390,
     weight: 0.94,
+    bayes: { prior: 0.9, likelihood: 0.95, evidence: 0.96, posterior: posterior(0.9, 0.95, 0.96), confidence: 0.93, note: "definable image" },
   },
   {
     id: "infinity",
@@ -118,6 +139,7 @@ export const zfNodes: ZFNode[] = [
     x: 440,
     y: 390,
     weight: 0.89,
+    bayes: { prior: 0.87, likelihood: 0.91, evidence: 0.94, posterior: posterior(0.87, 0.91, 0.94), confidence: 0.89, note: "inductive seed" },
   },
   {
     id: "foundation",
@@ -130,6 +152,7 @@ export const zfNodes: ZFNode[] = [
     x: 560,
     y: 315,
     weight: 0.86,
+    bayes: { prior: 0.83, likelihood: 0.87, evidence: 0.92, posterior: posterior(0.83, 0.87, 0.92), confidence: 0.85, note: "well-founded guard" },
   },
   {
     id: "membership",
@@ -142,6 +165,7 @@ export const zfNodes: ZFNode[] = [
     x: 280,
     y: 250,
     weight: 1,
+    bayes: { prior: 0.99, likelihood: 0.99, evidence: 0.99, posterior: posterior(0.99, 0.99, 0.99), confidence: 0.99, note: "primitive relation" },
   },
   {
     id: "subset",
@@ -154,6 +178,7 @@ export const zfNodes: ZFNode[] = [
     x: 430,
     y: 300,
     weight: 0.87,
+    bayes: { prior: 0.91, likelihood: 0.92, evidence: 0.94, posterior: posterior(0.91, 0.92, 0.94), confidence: 0.91, note: "derived relation" },
   },
   {
     id: "choice",
@@ -166,6 +191,7 @@ export const zfNodes: ZFNode[] = [
     x: 650,
     y: 170,
     weight: 0.72,
+    bayes: { prior: 0.68, likelihood: 0.76, evidence: 0.88, posterior: posterior(0.68, 0.76, 0.88), confidence: 0.72, note: "explicit extension" },
   },
 ];
 
@@ -188,8 +214,39 @@ export const zfPredicates = [
   "A = B ⇔ ∀x(x ∈ A ↔ x ∈ B)",
   "⋃A = {x | ∃y(y ∈ A ∧ x ∈ y)}",
   "P(A) = {x | x ⊆ A}",
+  "P(H|E) = P(E|H)P(H)/P(E)",
   "ZF + AC = ZFC",
 ];
+
+export const bayesianCoordinateFormula = "P(H|E) = P(E|H)P(H)/P(E)";
+
+export function bayesianUpdate(prior: number, likelihood: number, evidence: number) {
+  return posterior(prior, likelihood, evidence);
+}
+
+export function zfBayesianCoordinateSummary() {
+  const totals = zfNodes.reduce(
+    (acc, node) => {
+      acc.prior += node.bayes.prior;
+      acc.likelihood += node.bayes.likelihood;
+      acc.evidence += node.bayes.evidence;
+      acc.posterior += node.bayes.posterior;
+      acc.confidence += node.bayes.confidence;
+      return acc;
+    },
+    { prior: 0, likelihood: 0, evidence: 0, posterior: 0, confidence: 0 },
+  );
+
+  const count = zfNodes.length;
+
+  return {
+    meanPrior: Number((totals.prior / count).toFixed(3)),
+    meanLikelihood: Number((totals.likelihood / count).toFixed(3)),
+    meanEvidence: Number((totals.evidence / count).toFixed(3)),
+    meanPosterior: Number((totals.posterior / count).toFixed(3)),
+    meanConfidence: Number((totals.confidence / count).toFixed(3)),
+  };
+}
 
 export function zfNetworkHealth() {
   const axiomWeight = zfNodes
@@ -198,6 +255,7 @@ export function zfNetworkHealth() {
   const axiomCount = zfNodes.filter((node) => node.kind === "axiom").length;
   const guardEdges = zfEdges.filter((edge) => edge.kind === "guards").length;
   const extensionEdges = zfEdges.filter((edge) => edge.kind === "extends").length;
+  const bayes = zfBayesianCoordinateSummary();
 
   return {
     axiomCount,
@@ -207,5 +265,7 @@ export function zfNetworkHealth() {
     meanAxiomWeight: Number((axiomWeight / axiomCount).toFixed(3)),
     guardEdges,
     extensionEdges,
+    meanPosterior: bayes.meanPosterior,
+    meanBayesConfidence: bayes.meanConfidence,
   };
 }

--- a/data/zfSetTheory.ts
+++ b/data/zfSetTheory.ts
@@ -1,0 +1,211 @@
+export type ZFNodeKind = "axiom" | "operator" | "relation" | "extension";
+
+export type ZFNode = {
+  id: string;
+  label: string;
+  kind: ZFNodeKind;
+  symbol: string;
+  shortName: string;
+  description: string;
+  x: number;
+  y: number;
+  weight: number;
+};
+
+export type ZFEdgeKind = "defines" | "requires" | "constructs" | "guards" | "extends";
+
+export type ZFEdge = {
+  id: string;
+  from: string;
+  to: string;
+  kind: ZFEdgeKind;
+  label: string;
+};
+
+export const zfNodes: ZFNode[] = [
+  {
+    id: "extensionality",
+    label: "Extensionality",
+    kind: "axiom",
+    symbol: "A = B ⇔ ∀x(x ∈ A ↔ x ∈ B)",
+    shortName: "same members, same set",
+    description:
+      "Two sets are equal exactly when they have the same elements. This is the identity lock on the whole network.",
+    x: 280,
+    y: 70,
+    weight: 0.98,
+  },
+  {
+    id: "empty-set",
+    label: "Empty Set",
+    kind: "axiom",
+    symbol: "∃A∀x(x ∉ A)",
+    shortName: "nothing, formally",
+    description:
+      "There exists a set with no elements. The smallest clean room in the mathematical castle.",
+    x: 90,
+    y: 170,
+    weight: 0.82,
+  },
+  {
+    id: "pairing",
+    label: "Pairing",
+    kind: "axiom",
+    symbol: "∀a∀b∃c∀x(x ∈ c ↔ x=a ∨ x=b)",
+    shortName: "make {a,b}",
+    description:
+      "Any two objects can be gathered into a set. This is the first tiny basket-goblin, but it behaves.",
+    x: 200,
+    y: 210,
+    weight: 0.84,
+  },
+  {
+    id: "union",
+    label: "Union",
+    kind: "axiom",
+    symbol: "⋃A = {x | ∃y(y ∈ A ∧ x ∈ y)}",
+    shortName: "flatten one layer",
+    description:
+      "A set of sets can be flattened by one membership layer. Not all layers, just one. Precision matters; soup is not a theorem.",
+    x: 380,
+    y: 210,
+    weight: 0.88,
+  },
+  {
+    id: "power-set",
+    label: "Power Set",
+    kind: "axiom",
+    symbol: "P(A) = {x | x ⊆ A}",
+    shortName: "all subsets",
+    description:
+      "Every set has a set of all its subsets. This is where combinatorial goblins start multiplying.",
+    x: 510,
+    y: 170,
+    weight: 0.92,
+  },
+  {
+    id: "separation",
+    label: "Separation Schema",
+    kind: "axiom",
+    symbol: "{x ∈ A | φ(x)}",
+    shortName: "filter an existing set",
+    description:
+      "Predicates can carve subsets from an existing set. It does not create arbitrary universal mega-sets.",
+    x: 130,
+    y: 350,
+    weight: 0.9,
+  },
+  {
+    id: "replacement",
+    label: "Replacement Schema",
+    kind: "axiom",
+    symbol: "∀a∃b∀y(y ∈ b ↔ ∃x∈a φ(x,y))",
+    shortName: "image of a set",
+    description:
+      "A definable function sends a set-sized domain to a set-sized image. Very powerful; keep the logic leash clipped.",
+    x: 280,
+    y: 390,
+    weight: 0.94,
+  },
+  {
+    id: "infinity",
+    label: "Infinity",
+    kind: "axiom",
+    symbol: "∃I(∅ ∈ I ∧ ∀x∈I(x∪{x} ∈ I))",
+    shortName: "natural-number seed",
+    description:
+      "There exists an inductive set, giving the foundation for natural numbers. The counting goblin receives a legal badge.",
+    x: 440,
+    y: 390,
+    weight: 0.89,
+  },
+  {
+    id: "foundation",
+    label: "Foundation",
+    kind: "axiom",
+    symbol: "A≠∅ → ∃x∈A(x∩A=∅)",
+    shortName: "no infinite ∈-descent",
+    description:
+      "Every nonempty set has an element disjoint from it. This blocks circular membership weirdness in standard ZF.",
+    x: 560,
+    y: 315,
+    weight: 0.86,
+  },
+  {
+    id: "membership",
+    label: "Membership",
+    kind: "relation",
+    symbol: "x ∈ A",
+    shortName: "element relation",
+    description:
+      "The primitive relation of the network: one object is an element of a set.",
+    x: 280,
+    y: 250,
+    weight: 1,
+  },
+  {
+    id: "subset",
+    label: "Subset",
+    kind: "relation",
+    symbol: "A ⊆ B ⇔ ∀x(x ∈ A → x ∈ B)",
+    shortName: "membership containment",
+    description:
+      "Subset is defined through membership implication. It is not vibes; it is element-by-element containment.",
+    x: 430,
+    y: 300,
+    weight: 0.87,
+  },
+  {
+    id: "choice",
+    label: "Choice Extension",
+    kind: "extension",
+    symbol: "ZF + AC = ZFC",
+    shortName: "optional selector",
+    description:
+      "The axiom of choice is tracked as an extension point, not silently smuggled into ZF wearing a trench coat.",
+    x: 650,
+    y: 170,
+    weight: 0.72,
+  },
+];
+
+export const zfEdges: ZFEdge[] = [
+  { id: "e1", from: "membership", to: "extensionality", kind: "defines", label: "equality by ∈" },
+  { id: "e2", from: "membership", to: "subset", kind: "defines", label: "⊆ via ∈" },
+  { id: "e3", from: "empty-set", to: "infinity", kind: "requires", label: "∅ seed" },
+  { id: "e4", from: "pairing", to: "infinity", kind: "constructs", label: "successor" },
+  { id: "e5", from: "union", to: "infinity", kind: "constructs", label: "x ∪ {x}" },
+  { id: "e6", from: "subset", to: "power-set", kind: "defines", label: "all subsets" },
+  { id: "e7", from: "separation", to: "subset", kind: "constructs", label: "filtered subset" },
+  { id: "e8", from: "replacement", to: "union", kind: "constructs", label: "images collect" },
+  { id: "e9", from: "foundation", to: "membership", kind: "guards", label: "no ∈ loop" },
+  { id: "e10", from: "choice", to: "power-set", kind: "extends", label: "selectors" },
+];
+
+export const zfPredicates = [
+  "x ∈ A",
+  "A ⊆ B ⇔ ∀x(x ∈ A → x ∈ B)",
+  "A = B ⇔ ∀x(x ∈ A ↔ x ∈ B)",
+  "⋃A = {x | ∃y(y ∈ A ∧ x ∈ y)}",
+  "P(A) = {x | x ⊆ A}",
+  "ZF + AC = ZFC",
+];
+
+export function zfNetworkHealth() {
+  const axiomWeight = zfNodes
+    .filter((node) => node.kind === "axiom")
+    .reduce((sum, node) => sum + node.weight, 0);
+  const axiomCount = zfNodes.filter((node) => node.kind === "axiom").length;
+  const guardEdges = zfEdges.filter((edge) => edge.kind === "guards").length;
+  const extensionEdges = zfEdges.filter((edge) => edge.kind === "extends").length;
+
+  return {
+    axiomCount,
+    relationCount: zfNodes.filter((node) => node.kind === "relation").length,
+    extensionCount: zfNodes.filter((node) => node.kind === "extension").length,
+    edgeCount: zfEdges.length,
+    meanAxiomWeight: Number((axiomWeight / axiomCount).toFixed(3)),
+    guardEdges,
+    extensionEdges,
+  };
+}

--- a/docs/zf-set-theory-network.md
+++ b/docs/zf-set-theory-network.md
@@ -25,6 +25,7 @@ docs/zf-set-theory-network.md
 - Edges represent definition, construction, dependency, guard behavior, or extension behavior.
 - Membership is the primitive relation used to define equality and subset.
 - Choice is tracked as an explicit extension point, giving ZFC when added to ZF.
+- Bayesian coordinates are a visualization/ranking overlay, not proof values.
 
 ## Core predicates
 
@@ -34,8 +35,43 @@ A ⊆ B ⇔ ∀x(x ∈ A → x ∈ B)
 A = B ⇔ ∀x(x ∈ A ↔ x ∈ B)
 ⋃A = {x | ∃y(y ∈ A ∧ x ∈ y)}
 P(A) = {x | x ⊆ A}
+P(H|E) = P(E|H)P(H)/P(E)
 ZF + AC = ZFC
 ```
+
+## Bayesian coordinate layer
+
+The connector assigns each node a Bayesian coordinate object:
+
+```ts
+type BayesianCoordinate = {
+  prior: number;
+  likelihood: number;
+  evidence: number;
+  posterior: number;
+  confidence: number;
+  note: string;
+};
+```
+
+The update formula is:
+
+```txt
+P(H|E) = P(E|H)P(H)/P(E)
+```
+
+In this UI, the coordinate means:
+
+| Field | Meaning |
+|---|---|
+| `prior` | Starting relevance weight for the node in this connector. |
+| `likelihood` | How strongly the current evidence supports using this node in the network view. |
+| `evidence` | Normalizing evidence mass for the UI overlay. |
+| `posterior` | Updated coordinate used for display scaling. |
+| `confidence` | UI confidence in the node's placement/role. |
+| `note` | Human-readable reason for the coordinate. |
+
+These are not mathematical truth scores. A ZF axiom is not made more or less valid by the `posterior` field. The coordinate layer is for navigation, ranking, and visual emphasis. Do not let a Bayesian goblin sell you fake proof glitter.
 
 ## Included ZF nodes
 
@@ -70,6 +106,18 @@ edgeCount
 meanAxiomWeight
 guardEdges
 extensionEdges
+meanPosterior
+meanBayesConfidence
+```
+
+The data file also exports `zfBayesianCoordinateSummary()`, which reports:
+
+```txt
+meanPrior
+meanLikelihood
+meanEvidence
+meanPosterior
+meanConfidence
 ```
 
 These metrics are not mathematical truth scores. They are UI/system summary measures for the connector diagram.

--- a/docs/zf-set-theory-network.md
+++ b/docs/zf-set-theory-network.md
@@ -1,0 +1,75 @@
+# Zermelo-Fraenkel Set Theory Math Network Connector
+
+This module models Zermelo-Fraenkel set theory as a symbolic network connector.
+
+It is a formal scaffold, not a metaphysical engine. The notation is powerful, but the potato remains a potato.
+
+## Route
+
+```txt
+/math-network/zf
+```
+
+## Files
+
+```txt
+data/zfSetTheory.ts
+components/ZFSetTheoryConnector.tsx
+app/math-network/zf/page.tsx
+docs/zf-set-theory-network.md
+```
+
+## Network interpretation
+
+- Nodes represent axioms, relations, and extension points.
+- Edges represent definition, construction, dependency, guard behavior, or extension behavior.
+- Membership is the primitive relation used to define equality and subset.
+- Choice is tracked as an explicit extension point, giving ZFC when added to ZF.
+
+## Core predicates
+
+```txt
+x ∈ A
+A ⊆ B ⇔ ∀x(x ∈ A → x ∈ B)
+A = B ⇔ ∀x(x ∈ A ↔ x ∈ B)
+⋃A = {x | ∃y(y ∈ A ∧ x ∈ y)}
+P(A) = {x | x ⊆ A}
+ZF + AC = ZFC
+```
+
+## Included ZF nodes
+
+| Node | Kind | Purpose |
+|---|---:|---|
+| Extensionality | axiom | Defines set equality by shared membership. |
+| Empty Set | axiom | Establishes a set with no members. |
+| Pairing | axiom | Allows construction of `{a,b}`. |
+| Union | axiom | Flattens a set of sets by one membership layer. |
+| Power Set | axiom | Collects all subsets of a set. |
+| Separation Schema | axiom | Filters an existing set by a predicate. |
+| Replacement Schema | axiom | Maps a set-sized domain to a set-sized image. |
+| Infinity | axiom | Gives an inductive set for natural-number construction. |
+| Foundation | axiom | Blocks circular or infinitely descending membership chains in standard ZF. |
+| Membership | relation | Primitive element relation. |
+| Subset | relation | Membership containment relation. |
+| Choice Extension | extension | Optional AC extension, forming ZFC. |
+
+## Design rule
+
+The connector should make formal dependencies visible. It should not pretend that set theory is a magical ontology machine. ZF is a language and axiom system for building mathematics with precise rules. No universal-set goblin gets smuggled through the back door.
+
+## Network health
+
+The data file exports `zfNetworkHealth()`, which reports:
+
+```txt
+axiomCount
+relationCount
+extensionCount
+edgeCount
+meanAxiomWeight
+guardEdges
+extensionEdges
+```
+
+These metrics are not mathematical truth scores. They are UI/system summary measures for the connector diagram.


### PR DESCRIPTION
Closes #11.

Adds a Zermelo-Fraenkel set theory math network connector at `/math-network/zf`.

Included files:
- `data/zfSetTheory.ts`
- `components/ZFSetTheoryConnector.tsx`
- `app/math-network/zf/page.tsx`
- `docs/zf-set-theory-network.md`

What it does:
- Models ZF axioms, relations, and extension points as typed network nodes.
- Models membership, subset, union, power set, replacement, infinity, foundation, and choice-extension relations as typed edges.
- Adds Bayesian coordinates as a UI/ranking overlay using `P(H|E) = P(E|H)P(H)/P(E)`.
- Displays network health and Bayesian summary metrics.
- Keeps Choice explicit as an extension point: `ZF + AC = ZFC`.

Important framing:
Bayesian coordinates are not proof values. They are UI/navigation weights. ZF remains a formal axiom system; no probability goblin gets to certify mathematical truth by waving a spreadsheet wand.