### PR TITLE
Add GitHub Pages static export deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy static Next.js site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static export
+        run: GITHUB_PAGES=true npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
 
       - name: Build static export
         run: GITHUB_PAGES=true npm run build

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
+const isGitHubPages = process.env.GITHUB_PAGES === "true";
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: isGitHubPages ? "export" : undefined,
+  basePath: isGitHubPages ? "/nextjs-boilerplate" : undefined,
+  assetPrefix: isGitHubPages ? "/nextjs-boilerplate/" : undefined,
+  images: {
+    unoptimized: isGitHubPages,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #10.

Adds a GitHub Pages deployment path so the project has a non-Vercel deployment target while Vercel checks are blocked by external account/project status.

Included changes:
- Updates `next.config.ts` to enable static export only when `GITHUB_PAGES=true`.
- Uses `/nextjs-boilerplate` as the GitHub Pages base path and asset prefix.
- Sets `images.unoptimized` for static export compatibility.
- Adds `.github/workflows/pages.yml` to build with `GITHUB_PAGES=true npm run build` and deploy `./out` through GitHub Pages.
- Temporarily installs with `npm install --no-audit --no-fund`, matching PR #18, while `package-lock.json` is out of sync with `package.json`.

Reasoning:
The current Vercel checks point to a deployment/account-blocked page, which appears external to the code. GitHub Pages gives the repo a low-goblin static deployment bridge instead of letting Vercel ambiguity masquerade as code failure.

Follow-up cleanup:
- Sync `package-lock.json` with `package.json`.
- Switch this workflow back to `npm ci` once the lockfile is deterministic again.