### PR TITLE
Add GitHub Actions build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: npm build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - main
 
 env:
+  # Force JavaScript actions onto Node 24 while the app build still targets Node 20.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
 
       - name: Build Next.js app
         run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: npm build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js app
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install --no-audit --no-fund
+        run: npm ci
 
       - name: Build Next.js app
         run: npm run build


### PR DESCRIPTION
Adds a repo-owned build check so PRs can distinguish code/build failures from external deployment blockers.

Workflow:
- Runs on pull requests and pushes to `main`
- Uses Node 20
- Forces JavaScript actions to Node 24 with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` while the app itself builds on Node 20
- Temporarily installs with `npm install --no-audit --no-fund` while `package-lock.json` is out of sync with `package.json`
- Runs `npm run build`

Temporary validation base:
- This PR is currently based on `restore-llm-helper-modules` so the workflow can validate with both prerequisite fixes included:
  - #21 fixes `@/* -> ./src/*`
  - #28 restores the missing `src/lib/llm/*` helper modules
- After #21 and #28 land on `main`, retarget this PR back to `main` before merging.

This gives the code goblin its own scoreboard instead of letting the Vercel deployment blocker wear a fake compiler mustache.

Longer-term cleanup: sync the lockfile and switch the install step back to `npm ci` for deterministic builds.

Depends on: #21 and #28
Related: #20