### PR TITLE
Fix src path alias for GRIPLOOM imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,9 @@
         "name": "next"
       }
     ],
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
Fixes the TypeScript module resolution failure uncovered by the repo-owned build check.

The file `src/lib/griploom/types.ts` exists on `main`, but `tsconfig.json` mapped `@/*` to the repository root (`./*`). That made `@/lib/griploom/types` resolve as `./lib/griploom/types` instead of `./src/lib/griploom/types`.

Changes:
- Adds `baseUrl: "."`
- Updates `@/*` to `./src/*`

This should let the existing GRIPLOOM shared type module resolve correctly during `npm run build`.

Related: #19.