### PR TITLE
Restore missing LLM helper modules

### DIFF
--- a/src/lib/llm/goblin-control-deck-health.ts
+++ b/src/lib/llm/goblin-control-deck-health.ts
@@ -1,0 +1,39 @@
+import { createGoblinControlDeckManifest } from "./goblin-control-deck-manifest";
+
+export function createGoblinControlDeckHealth() {
+  const manifest = createGoblinControlDeckManifest();
+  const dashboardCount = manifest.items.filter((item) => item.kind === "dashboard").length;
+  const apiCount = manifest.items.filter((item) => item.kind === "api").length;
+  const receiptIds = manifest.items.map((item) => `receipt-${item.id}`);
+  const duplicateReceiptIds = receiptIds.filter((id, index) => receiptIds.indexOf(id) !== index);
+  const layers = Array.from(new Set(manifest.items.map((item) => item.layer)));
+
+  const layerHealth = layers.map((layer) => {
+    const layerItems = manifest.items.filter((item) => item.layer === layer);
+    return {
+      layer,
+      routeCount: layerItems.length,
+      dashboardCount: layerItems.filter((item) => item.kind === "dashboard").length,
+      apiCount: layerItems.filter((item) => item.kind === "api").length,
+      healthyCount: layerItems.filter((item) => item.hasReceipt && item.hasLaw).length,
+    };
+  });
+
+  const healthy = manifest.items.every((item) => item.hasReceipt && item.hasLaw) && duplicateReceiptIds.length === 0;
+
+  return {
+    status: healthy ? "healthy" : "needs-attention",
+    dashboardCount,
+    apiCount,
+    receiptCount: receiptIds.length,
+    duplicateReceiptIds,
+    layerHealth,
+    items: manifest.items,
+    receipt: {
+      id: "receipt-goblin-control-deck-health-013",
+      kind: "llm-goblin-control-deck-health",
+      status: healthy ? "clear" : "attention",
+      law: "Health is computed from explicit receipts, laws, and route inventory. Spreadsheet wand not accepted as proof.",
+    },
+  };
+}

--- a/src/lib/llm/goblin-control-deck-manifest.ts
+++ b/src/lib/llm/goblin-control-deck-manifest.ts
@@ -1,0 +1,36 @@
+export type GoblinDeckItem = {
+  id: string;
+  kind: "dashboard" | "api" | "helper";
+  layer: string;
+  path: string;
+  status: "active" | "visible" | "draft";
+  hasReceipt: boolean;
+  hasLaw: boolean;
+};
+
+const items: GoblinDeckItem[] = [
+  { id: "goblin-health-api", kind: "api", layer: "diagnostics", path: "/api/llm/goblin-control-deck-health", status: "active", hasReceipt: true, hasLaw: true },
+  { id: "goblin-health-page", kind: "dashboard", layer: "diagnostics", path: "/goblin/health", status: "visible", hasReceipt: true, hasLaw: true },
+  { id: "goblin-manifest-api", kind: "api", layer: "manifest", path: "/api/llm/goblin-control-deck", status: "active", hasReceipt: true, hasLaw: true },
+  { id: "observer-constellations-api", kind: "api", layer: "observer", path: "/api/llm/observer-constellations", status: "active", hasReceipt: true, hasLaw: true },
+  { id: "observer-constellations-page", kind: "dashboard", layer: "observer", path: "/goblin/constellations", status: "visible", hasReceipt: true, hasLaw: true },
+  { id: "observer-parallax-api", kind: "api", layer: "observer", path: "/api/llm/observer-parallax", status: "active", hasReceipt: true, hasLaw: true },
+  { id: "observer-parallax-page", kind: "dashboard", layer: "observer", path: "/goblin/parallax", status: "visible", hasReceipt: true, hasLaw: true },
+  { id: "observer-route-api", kind: "api", layer: "routing", path: "/api/llm/observer-route", status: "active", hasReceipt: true, hasLaw: true },
+  { id: "observer-route-page", kind: "dashboard", layer: "routing", path: "/goblin/observer-route", status: "visible", hasReceipt: true, hasLaw: true },
+];
+
+export function createGoblinControlDeckManifest() {
+  return {
+    title: "Goblin Control Deck Manifest",
+    law: "Every visible Goblin route needs a receipt, a layer, and a deterministic helper. No fog-machine APIs pretending to be architecture.",
+    items,
+    routes: items.map((item) => item.path),
+    receipt: {
+      id: "receipt-goblin-control-deck-manifest-009",
+      kind: "llm-goblin-control-deck-manifest",
+      status: "active",
+      law: "Route authority is explicit, helper-backed, and build-testable.",
+    },
+  };
+}

--- a/src/lib/llm/observer-constellations.ts
+++ b/src/lib/llm/observer-constellations.ts
@@ -1,0 +1,84 @@
+export type ObserverName = "earth" | "mars";
+
+export type ObserverConstellation = {
+  id: string;
+  name: string;
+  anchor: string;
+  goblinRoute: string;
+  mythicRole: string;
+  notes: string;
+  keywords: string[];
+};
+
+const earth: ObserverConstellation[] = [
+  {
+    id: "earth_orion",
+    name: "Orion / Winter Hunter",
+    anchor: "Belt stars as a winter sky ruler",
+    goblinRoute: "orion_arc",
+    mythicRole: "Creative synthesis, alignment, and pattern recognition.",
+    notes: "Earth view treats Orion as a familiar seasonal marker rather than a universal sticker on the dome. The dome goblin receives no crown.",
+    keywords: ["orion", "winter", "hunter", "belt", "creative", "synthesis", "alignment"],
+  },
+  {
+    id: "earth_polaris",
+    name: "Polaris / North Home Pin",
+    anchor: "North celestial pole neighborhood",
+    goblinRoute: "earth_gate",
+    mythicRole: "Home orientation, return bearing, and calm navigation.",
+    notes: "Useful for Earth navigation; less useful once the observer moves worlds.",
+    keywords: ["north", "home", "pointer", "polaris", "return", "bearing", "orientation"],
+  },
+  {
+    id: "earth_scorpius",
+    name: "Scorpius / Warning Hook",
+    anchor: "Low summer southern arc",
+    goblinRoute: "bz_shield",
+    mythicRole: "Risk signal, heat warning, and boundary check.",
+    notes: "A danger glyph in the dashboard, not a prophecy machine wearing a tiny hat.",
+    keywords: ["risk", "sting", "scorpion", "heat", "warning", "flare", "shield"],
+  },
+];
+
+const mars: ObserverConstellation[] = [
+  {
+    id: "mars_earth_moon",
+    name: "Earth-Moon Beacon",
+    anchor: "Earth and Moon as a return-light pair",
+    goblinRoute: "earth_gate",
+    mythicRole: "Expedition memory, home reference, and return logic.",
+    notes: "From Mars, Earth becomes the tiny blue-white reference lamp. Humbling. Excellent anti-pretension medicine.",
+    keywords: ["earth", "moon", "return", "beacon", "home", "blue", "memory"],
+  },
+  {
+    id: "mars_phobos_deimos",
+    name: "Phobos-Deimos Fast Moons",
+    anchor: "Rapid local moon timing",
+    goblinRoute: "solar_system",
+    mythicRole: "Local cadence, operational timing, and fear/terror label audit.",
+    notes: "Mars has weird tiny moon goblins, and they move fast enough to matter in local stories.",
+    keywords: ["phobos", "deimos", "fast", "moons", "fear", "terror", "shield", "local"],
+  },
+  {
+    id: "mars_arcturus_reference",
+    name: "Arcturus Reference Beam",
+    anchor: "Bright distant star as deep-sky reference",
+    goblinRoute: "arcturus_gate",
+    mythicRole: "Stable comparison point for cross-observer reasoning.",
+    notes: "Deep sky anchors change slowly compared with local foregrounds, which is the useful trick.",
+    keywords: ["arcturus", "reference", "beam", "source", "deep", "stable", "check"],
+  },
+];
+
+export function createObserverConstellationMap() {
+  return {
+    rule: "Observer first, constellation second: Earth and Mars share deep sky, but local foregrounds change the route meaning.",
+    earth,
+    mars,
+    bridge: {
+      law: "Mark the observing world before interpreting the sky.",
+      parallaxNote: "Deep-sky constellations remain visually familiar at human dashboard scale, while nearby foreground bodies and navigation meanings shift.",
+      goblinUse: "Goblin routing uses the observer as a first-class input so a home beacon is not confused with an expedition beacon.",
+    },
+  };
+}

--- a/src/lib/llm/observer-parallax.ts
+++ b/src/lib/llm/observer-parallax.ts
@@ -1,0 +1,53 @@
+import { createObserverConstellationMap } from "./observer-constellations";
+
+export type ObserverParallaxPair = {
+  earthId: string;
+  marsId: string;
+  sharedRoute: string;
+  localForegroundShift: string;
+  goblinMeaning: string;
+  deepSkyStable: boolean;
+};
+
+export function createObserverParallaxMap() {
+  const constellations = createObserverConstellationMap();
+
+  const pairs: ObserverParallaxPair[] = [
+    {
+      earthId: "earth_polaris",
+      marsId: "mars_earth_moon",
+      sharedRoute: "earth_gate",
+      localForegroundShift: "Earth uses Polaris as a north-home reference; Mars uses Earth-Moon as the home beacon.",
+      goblinMeaning: "Same emotional route, different physical anchor. The map is not the territory; the goblin is forced to read the label.",
+      deepSkyStable: false,
+    },
+    {
+      earthId: "earth_orion",
+      marsId: "mars_arcturus_reference",
+      sharedRoute: "arcturus_gate",
+      localForegroundShift: "Orion gives a familiar Earth seasonal arc; Arcturus gives a steadier deep-sky comparison point.",
+      goblinMeaning: "Use deep references for cross-world continuity and local constellations for observer-facing narrative.",
+      deepSkyStable: true,
+    },
+    {
+      earthId: "earth_scorpius",
+      marsId: "mars_phobos_deimos",
+      sharedRoute: "bz_shield",
+      localForegroundShift: "Earth warning imagery leans on Scorpius; Mars warning imagery can lean on the fast local moons.",
+      goblinMeaning: "Risk signs are observer-local. A useful warning glyph on one world may be nonsense confetti on another.",
+      deepSkyStable: false,
+    },
+  ];
+
+  return {
+    rule: constellations.bridge.parallaxNote,
+    pairs,
+    receipt: {
+      id: "receipt-observer-parallax-map-010",
+      kind: "llm-observer-parallax-map",
+      status: "active",
+      observers: ["earth", "mars"],
+      law: "Local foregrounds shift; deep references stabilize; observer context always comes first.",
+    },
+  };
+}

--- a/src/lib/llm/observer-route-resolver.ts
+++ b/src/lib/llm/observer-route-resolver.ts
@@ -1,0 +1,47 @@
+import { createObserverConstellationMap, type ObserverName } from "./observer-constellations";
+import { createObserverParallaxMap } from "./observer-parallax";
+
+export type ObserverRouteInput = {
+  observer: ObserverName;
+  prompt: string;
+};
+
+export type ObserverRouteResult = {
+  observer: ObserverName;
+  route: string;
+  matchedConstellationId: string;
+  matchedConstellationName: string;
+  parallaxPair: string | null;
+  reason: string;
+};
+
+function scorePrompt(prompt: string, keywords: string[]) {
+  const haystack = prompt.toLowerCase();
+  return keywords.reduce((score, keyword) => score + (haystack.includes(keyword) ? 1 : 0), 0);
+}
+
+export function resolveObserverRoute(input: ObserverRouteInput): ObserverRouteResult {
+  const map = createObserverConstellationMap();
+  const parallax = createObserverParallaxMap();
+  const options = input.observer === "earth" ? map.earth : map.mars;
+
+  const ranked = options
+    .map((item) => ({ item, score: scorePrompt(input.prompt, item.keywords) }))
+    .sort((a, b) => b.score - a.score);
+
+  const match = ranked[0]?.score > 0 ? ranked[0].item : options[0];
+  const pair = parallax.pairs.find((candidate) =>
+    input.observer === "earth"
+      ? candidate.earthId === match.id
+      : candidate.marsId === match.id,
+  );
+
+  return {
+    observer: input.observer,
+    route: match.goblinRoute,
+    matchedConstellationId: match.id,
+    matchedConstellationName: match.name,
+    parallaxPair: pair ? `${pair.earthId} ↔ ${pair.marsId}` : null,
+    reason: `Matched ${match.name} because the ${input.observer} observer prompt overlapped with this route's keyword field. Observer first, route second, cosmic soup not allowed to pretend it is a spreadsheet.`,
+  };
+}


### PR DESCRIPTION
Closes #27.

Adds the missing deterministic helper modules under `src/lib/llm` so the existing Goblin/Observer API routes and pages can resolve their imports after PR #21 fixes the path alias.

Added helpers:
- `observer-constellations.ts`
- `observer-parallax.ts`
- `observer-route-resolver.ts`
- `goblin-control-deck-manifest.ts`
- `goblin-control-deck-health.ts`

Design notes:
- Helpers are build-safe and deterministic; no external LLM/API calls are required.
- Observer routing stays explicit: observer first, constellation second, route third.
- Health is computed from manifest items, receipt/law flags, and duplicate receipt IDs.

This should move PR #18 past the missing `@/lib/llm/*` module failures once stacked after #21. New goblin, proper cage.