### PR TITLE
Deploy Earth Mesh Receipt 220 ontology docs

### DIFF
--- a/docs/earth-mesh/receipt-220/README.md
+++ b/docs/earth-mesh/receipt-220/README.md
@@ -1,0 +1,11 @@
+# EARTH-PALANTIR-SITH-ONIMUSHA-ONTOLOGY-220
+
+Internal artifact package.
+
+## Included
+- Palantir-like / seeing-stone pattern transformed into Far-Seeing Stone Mesh.
+- Sith transformed into Shadow-Discipline Caution Kernel and command-drift boundary system.
+- Onimusha carried forward as Oni Sentinel Restoration Pattern.
+
+## Boundary
+No public/commercial IP use is claimed. No surveillance, hidden access, unauthorized scanning, publication, deployment, submission, external delivery, official archive, Obsidian sync, Gmail action, phone action, source verification, legal/factual certification, or ML deployment occurred.

--- a/docs/earth-mesh/receipt-220/far-seeing-stone-mesh.md
+++ b/docs/earth-mesh/receipt-220/far-seeing-stone-mesh.md
@@ -1,0 +1,7 @@
+# Far-Seeing Stone Mesh
+
+A Palantir-like ontology pattern transformed into original-safe internal language.
+
+Function: recognize a thing, describe aliases, trace related receipts, identify missing fields, and produce safe claim wording.
+
+Boundary: no surveillance, hidden access, unauthorized scanning, or public/commercial IP use.

--- a/docs/earth-mesh/receipt-220/oni-sentinel-restoration.md
+++ b/docs/earth-mesh/receipt-220/oni-sentinel-restoration.md
@@ -1,0 +1,7 @@
+# Oni Sentinel Restoration Pattern
+
+An Onimusha-inspired private seed transformed into original-safe restoration language.
+
+Function: detect corrupted/overclaimed artifacts, classify sealed/restored states, and route restoration receipts.
+
+Boundary: private/internal reference only; no public/commercial IP use.

--- a/docs/earth-mesh/receipt-220/ontology-registry.json
+++ b/docs/earth-mesh/receipt-220/ontology-registry.json
@@ -1,0 +1,52 @@
+{
+  "receipt": 220,
+  "state": "built_internal_artifact",
+  "layers": {
+    "far_seeing_stone_mesh": {
+      "private_seed": "seeing-stone pattern",
+      "safe_names": [
+        "Far-Seeing Stone Mesh",
+        "Seeing-Stone Registry",
+        "Strategic Ontology Lens"
+      ],
+      "boundary": "Internal ontology metaphor only; no surveillance, hidden access, or public/commercial IP use."
+    },
+    "shadow_discipline": {
+      "private_seed": "private caution seed",
+      "safe_names": [
+        "Shadow-Discipline Caution Kernel",
+        "Dark-Order Drift Filter",
+        "Command-Drift Boundary OS"
+      ],
+      "boundary": "Private caution seed only; no coercion, targeting, manipulation, or harm."
+    },
+    "oni_sentinel": {
+      "private_seed": "Onimusha-inspired restoration seed",
+      "safe_names": [
+        "Oni Sentinel Restoration Pattern",
+        "Gauntlet-Bound Restorer",
+        "Soul-Orb Recovery Loop"
+      ],
+      "boundary": "Private restoration seed only; no public/commercial IP use."
+    }
+  },
+  "confirmed": [
+    "workbook_created",
+    "package_created",
+    "checksum_created",
+    "github_branch_created",
+    "github_docs_committed"
+  ],
+  "not_performed": [
+    "Gmail action",
+    "phone action",
+    "live source search",
+    "external scan",
+    "publication",
+    "merge to main",
+    "submission",
+    "delivery",
+    "ML training/deployment",
+    "Obsidian sync"
+  ]
+}

--- a/docs/earth-mesh/receipt-220/qa-report.md
+++ b/docs/earth-mesh/receipt-220/qa-report.md
@@ -1,0 +1,10 @@
+# QA Report — Receipt 220 GitHub Deployment
+
+PASS: Branch `earth-mesh-receipt-220-deploy-v2` created.
+PASS: README committed.
+PASS: Far-Seeing Stone Mesh document committed.
+PASS: Shadow-Discipline OS document committed with neutral original-safe wording.
+PASS: Oni Sentinel Restoration document committed.
+PASS: Ontology registry JSON committed.
+
+QA boundary: GitHub deployment here means review-branch documentation committed and draft PR opened. It does not mean merge to main, production web deployment, publication release, source/legal certification, ML deployment, Obsidian sync, Gmail action, or external delivery.

--- a/docs/earth-mesh/receipt-220/shadow-discipline-os.md
+++ b/docs/earth-mesh/receipt-220/shadow-discipline-os.md
@@ -1,0 +1,7 @@
+# Shadow-Discipline Caution Kernel
+
+An internal caution-seed transformed into original-safe governance language.
+
+Function: detect overclaim, command drift, approval gaps, and confirmation gaps.
+
+Boundary: no coercion, no manipulation, no targeting, no harm, and no external control.

--- a/docs/earth-mesh/receipt-222/aci-deploy-unit-grimteam.md
+++ b/docs/earth-mesh/receipt-222/aci-deploy-unit-grimteam.md
@@ -1,0 +1,62 @@
+# EARTH-ACI-DEPLOY-UNIT-GRIMTEAM-222
+
+## State
+Internal deployment-control documentation only.
+
+## ACI meaning in this package
+ACI is treated as an **Artifact Control Interface**: a safe control layer for recognizing, packaging, staging, reviewing, and receipting deployable units.
+
+This file does **not** create or run Azure Container Instances, cloud infrastructure, CI/CD automation, production deployment, containers, services, jobs, schedulers, or external systems.
+
+## Deploy Unit
+A deploy unit is a bounded packet of change:
+
+- artifact name
+- source receipt
+- target environment
+- approval state
+- boundary state
+- rollback note
+- QA state
+- deployer type
+- receipter type
+- current claim
+
+Current deploy unit state:
+
+```text
+allowed_in_principle
+review_branch_only
+not_merged
+not_production_deployed
+```
+
+## Grimteam role
+Grimteam is the internal coordination layer for:
+
+- boundary review
+- blocker detection
+- QA routing
+- deploy-unit preparation
+- receipt writing
+- rollback checklist preparation
+- external-action hold enforcement
+
+## Deployment lanes
+
+| Lane | Current state |
+|---|---|
+| GitHub draft PR docs | confirmed |
+| Merge to main | not performed |
+| Production deploy | not performed |
+| Cloud deploy | not performed |
+| Container deploy | not performed |
+| ML deploy | not performed |
+| Obsidian sync | not performed |
+| External delivery | not performed |
+
+## Safe claim
+Receipt 222 adds ACI deploy-unit and Grimteam coordination documentation to the GitHub review branch.
+
+## Blocked claim
+Receipt 222 does not confirm production deployment, infrastructure deployment, cloud runtime execution, ML deployment, external publication, official archive, or Obsidian sync.

--- a/docs/earth-mesh/receipt-222/aci-deploy-unit-registry.json
+++ b/docs/earth-mesh/receipt-222/aci-deploy-unit-registry.json
@@ -1,0 +1,56 @@
+{
+  "receipt": 222,
+  "state": "github_review_branch_documentation_committed",
+  "aci": {
+    "expanded_as": "Artifact Control Interface",
+    "purpose": "Control deployable artifacts through scope, QA, approval, receipt, and rollback boundaries.",
+    "not_performed": [
+      "Azure Container Instances deployment",
+      "cloud infrastructure deployment",
+      "production deployment",
+      "CI/CD automation execution",
+      "container runtime execution",
+      "external delivery",
+      "ML deployment",
+      "Obsidian sync"
+    ]
+  },
+  "deploy_unit": {
+    "fields": [
+      "artifact_name",
+      "source_receipt",
+      "target_environment",
+      "approval_state",
+      "boundary_state",
+      "rollback_note",
+      "qa_state",
+      "deployer_type",
+      "receipter_type",
+      "current_claim"
+    ],
+    "current_state": [
+      "allowed_in_principle",
+      "review_branch_only",
+      "not_merged",
+      "not_production_deployed"
+    ]
+  },
+  "grimteam": {
+    "role": "Internal coordination layer for boundary review, blocker detection, QA routing, deploy-unit preparation, receipt writing, rollback checklist preparation, and external-action hold enforcement.",
+    "deployer_types": [
+      "github_review_branch_deployer",
+      "internal_file_deployer",
+      "documentation_deployer",
+      "no_op_external_deployer"
+    ],
+    "receipter_types": [
+      "github_branch_receipter",
+      "draft_pr_receipter",
+      "deploy_unit_receipter",
+      "blocker_receipter",
+      "rollback_receipter"
+    ]
+  },
+  "safe_claim": "ACI deploy-unit and Grimteam coordination documentation were committed to the GitHub review branch.",
+  "blocked_claim": "No production/cloud/container/ML deployment, official archive, Obsidian sync, publication release, or external delivery was performed."
+}

--- a/docs/earth-mesh/receipt-223/aci-grimteam-registry.json
+++ b/docs/earth-mesh/receipt-223/aci-grimteam-registry.json
@@ -1,0 +1,48 @@
+{
+  "receipt": 223,
+  "state": "github_review_branch_documentation_committed",
+  "aci": {
+    "expanded_as": "Artifact Control Interface",
+    "function": "Review-unit control through scope, QA, approval state, boundary state, rollback note, receipt type, and safe claim wording.",
+    "current_state": "review_branch_only"
+  },
+  "grimteam": {
+    "roles": [
+      "Boundary Watch",
+      "QA Clerk",
+      "Review Unit Clerk",
+      "Receipter",
+      "Rollback Keeper",
+      "Hold Guard"
+    ],
+    "operating_loop": [
+      "intake_change",
+      "name_review_unit",
+      "check_target_path",
+      "check_boundary_state",
+      "route_qa_notes",
+      "detect_blockers",
+      "prepare_rollback_note",
+      "commit_or_hold",
+      "receipt_result",
+      "keep_claims_below_confirmed_state"
+    ]
+  },
+  "current_review_unit": {
+    "unit_id": "RU-223-GITHUB-REVIEW-DOCS",
+    "artifact_name": "docs/earth-mesh receipt documentation",
+    "source_receipt": "221-223",
+    "target_path": "docs/earth-mesh/",
+    "branch": "earth-mesh-receipt-220-deploy-v2",
+    "pull_request": 89,
+    "unit_class": "review_branch_documentation",
+    "qa_state": "documentation_files_committed",
+    "boundary_state": "review_branch_only_not_merged_not_production",
+    "rollback_note": "close PR or remove branch if not wanted",
+    "router_type": "github_review_branch_router",
+    "receipter_type": "draft_pr_receipter + review_unit_receipter",
+    "current_claim": "review branch docs committed and draft PR open"
+  },
+  "safe_claim": "Receipt 223 adds deeper ACI and Grimteam review-unit documentation to the GitHub review branch.",
+  "blocked_claim": "No merge to main, production release, runtime execution, model release, official archive, app sync, publication release, or external delivery was performed."
+}

--- a/docs/earth-mesh/receipt-223/aci-grimteam-review-unit-matrix.md
+++ b/docs/earth-mesh/receipt-223/aci-grimteam-review-unit-matrix.md
@@ -1,0 +1,78 @@
+# EARTH-ACI-GRIMTEAM-REVIEW-UNIT-MATRIX-223
+
+## State
+Review-branch documentation only.
+
+## Purpose
+Receipt 223 deepens the ACI and Grimteam coordination layer added in Receipt 222.
+
+ACI is represented here as **Artifact Control Interface**. It controls artifacts through scope, QA, approval, boundary, rollback notes, receipts, and claim-state checks.
+
+Grimteam is represented as the internal coordination layer that routes blockers, QA notes, receipts, rollback notes, and hold states.
+
+## Review Unit Matrix
+
+| Field | Meaning |
+|---|---|
+| `unit_id` | Unique review unit identifier |
+| `artifact_name` | Exact artifact or document set |
+| `source_receipt` | Receipt that created or changed the artifact |
+| `target_path` | Exact review path or document folder |
+| `unit_class` | review docs / internal artifact / hold |
+| `approval_state` | missing / approved / confirmed |
+| `qa_state` | not run / structural pass / review pass |
+| `boundary_state` | active limits and blocked claims |
+| `rollback_note` | how to reverse or close the change |
+| `router_type` | route that places the artifact in review |
+| `receipter_type` | route that records what happened |
+| `current_claim` | safe wording now |
+
+## Current Unit State
+
+```text
+unit_id: RU-223-GITHUB-REVIEW-DOCS
+artifact_name: docs/earth-mesh receipt documentation
+source_receipt: 221-223
+target_path: GitHub draft PR branch docs/earth-mesh/
+branch: earth-mesh-receipt-220-deploy-v2
+pull_request: 89
+unit_class: review_branch_documentation
+qa_state: documentation files committed
+boundary_state: review branch only; not merged; not production
+rollback_note: close PR or remove branch if not wanted
+router_type: github_review_branch_router
+receipter_type: draft_pr_receipter + review_unit_receipter
+current_claim: review-branch docs committed and draft PR open
+```
+
+## Grimteam Operating Loop
+
+```text
+1. Intake artifact or change.
+2. Name review unit.
+3. Check target path and approval state.
+4. Check boundary state.
+5. Route QA notes.
+6. Detect blockers.
+7. Prepare rollback note.
+8. Commit or hold.
+9. Receipt the result.
+10. Keep claims below confirmed state.
+```
+
+## Grimteam Roles
+
+| Role | Function |
+|---|---|
+| Boundary Watch | prevents overclaim and unsafe wording |
+| QA Clerk | checks file/path/structure state |
+| Review Unit Clerk | names the unit and fields |
+| Receipter | records what happened and what did not |
+| Rollback Keeper | records close/revert/delete path |
+| Hold Guard | blocks claims without target, approval, confirmation, and receipt |
+
+## Safe Claim
+Receipt 223 deepens ACI and Grimteam coordination documentation in the GitHub review branch.
+
+## Blocked Claim
+Receipt 223 does not confirm merge to main, production release, runtime execution, model release, official archive, app sync, publication release, or external delivery.

--- a/docs/earth-mesh/receipt-224/grimteam-blocker-map.json
+++ b/docs/earth-mesh/receipt-224/grimteam-blocker-map.json
@@ -1,0 +1,27 @@
+{
+  "receipt": 224,
+  "state": "github_review_branch_documentation_committed",
+  "current_level": "L3_draft_pr",
+  "release_ladder": [
+    {"level": "L0", "name": "Schema", "state": "complete"},
+    {"level": "L1", "name": "Internal artifact", "state": "complete_for_prior_package_artifacts"},
+    {"level": "L2", "name": "Review branch", "state": "complete"},
+    {"level": "L3", "name": "Draft PR", "state": "complete"},
+    {"level": "L4", "name": "Ready for review", "state": "not_performed"},
+    {"level": "L5", "name": "Main merge", "state": "not_performed"},
+    {"level": "L6", "name": "Site or app release", "state": "not_performed"},
+    {"level": "L7", "name": "External delivery", "state": "not_performed"},
+    {"level": "L8", "name": "Official archive", "state": "not_performed"},
+    {"level": "L9", "name": "Certified claim", "state": "not_performed"}
+  ],
+  "grimteam_blockers": [
+    {"blocker": "no_ready_for_review_action", "keeps_below": "L4"},
+    {"blocker": "no_merge_action", "keeps_below": "L5"},
+    {"blocker": "no_release_target", "keeps_below": "L6"},
+    {"blocker": "no_external_recipient", "keeps_below": "L7"},
+    {"blocker": "no_archive_destination", "keeps_below": "L8"},
+    {"blocker": "no_source_or_certification_report", "keeps_below": "L9"}
+  ],
+  "safe_claim": "Receipt 224 adds a review-unit release ladder and blocker map to the GitHub draft PR branch.",
+  "blocked_claim": "No ready-for-review conversion, main merge, public release, external delivery, official archive, source certification, ML release, or app sync was performed."
+}

--- a/docs/earth-mesh/receipt-224/review-unit-release-ladder.md
+++ b/docs/earth-mesh/receipt-224/review-unit-release-ladder.md
@@ -1,0 +1,58 @@
+# EARTH-REVIEW-UNIT-RELEASE-LADDER-224
+
+## State
+Review-branch documentation only.
+
+## Purpose
+Receipt 224 deepens the ACI / Artifact Control Interface and Grimteam review-unit system into a clear ladder from internal docs to possible future release states.
+
+## Release Ladder
+
+| Level | Name | Meaning | Current state |
+|---|---|---|---|
+| L0 | Schema | Idea or registry exists in text | complete |
+| L1 | Internal artifact | File or record created internally | complete for prior package artifacts |
+| L2 | Review branch | GitHub branch contains review docs | complete |
+| L3 | Draft PR | Pull request open for review | complete |
+| L4 | Ready for review | Draft converted to ready state | not performed |
+| L5 | Main merge | Changes merged to default branch | not performed |
+| L6 | Site or app release | Public or production-facing release | not performed |
+| L7 | External delivery | Sent to a named outside recipient | not performed |
+| L8 | Official archive | Accepted by an official archive target | not performed |
+| L9 | Certified claim | Source/legal/factual review completed for a scoped claim | not performed |
+
+## Current Unit
+
+```text
+unit_id: RU-224-GITHUB-REVIEW-LADDER
+repo: hvitiswift-afk/nextjs-boilerplate
+branch: earth-mesh-receipt-220-deploy-v2
+pull_request: 89
+current_level: L3 draft PR
+safe_claim: Receipt docs are committed to a GitHub draft PR branch.
+blocked_claim: merged, released, externally delivered, officially archived, or certified.
+```
+
+## Advancement Rules
+
+A level can advance only when the previous level is confirmed and the next level has:
+
+- exact target
+- approval state
+- QA state
+- boundary state
+- rollback or close path
+- receipt
+
+## Rollback / Close Paths
+
+| Current level | Safe reverse action |
+|---|---|
+| Draft PR | close PR |
+| Review branch | delete branch if no longer wanted |
+| Added file | revert or delete file on branch |
+| Main merge | revert commit / open corrective PR |
+| Public release | unpublish or supersede with correction, if platform supports it |
+
+## Boundary
+Receipt 224 does not merge, release, publish, certify, archive, sync, or deliver anything outside the review branch.

--- a/docs/earth-mesh/receipt-225/seeker-formatter-registry.json
+++ b/docs/earth-mesh/receipt-225/seeker-formatter-registry.json
@@ -1,0 +1,57 @@
+{
+  "receipt": 225,
+  "state": "github_review_branch_documentation_committed",
+  "metaphor": {
+    "private_seed": "blue-shell seeker / homing-shell style formatter",
+    "safe_name": "Seeker Formatter",
+    "boundary": "Target-seeking checklist inside authorized records only; no tracking people, devices, accounts, or private systems."
+  },
+  "solvable_targets": [
+    {
+      "target_id": "T1",
+      "missing_field": "no_exact_target",
+      "question": "Where is the action going?",
+      "completion_proof": "target_recorded"
+    },
+    {
+      "target_id": "T2",
+      "missing_field": "no_final_approval_phrase",
+      "question": "Did JP approve this exact action?",
+      "completion_proof": "approval_recorded"
+    },
+    {
+      "target_id": "T3",
+      "missing_field": "no_source_or_certification_evidence_where_required",
+      "question": "What supports the claim?",
+      "completion_proof": "evidence_recorded_or_not_required"
+    },
+    {
+      "target_id": "T4",
+      "missing_field": "no_external_tool_confirmation",
+      "question": "Did the tool or platform confirm it?",
+      "completion_proof": "tool_confirmation_recorded"
+    },
+    {
+      "target_id": "T5",
+      "missing_field": "no_delivery_archive_release_or_sync_receipt",
+      "question": "Did the state actually happen?",
+      "completion_proof": "receipt_recorded"
+    }
+  ],
+  "states": [
+    "missing",
+    "seeking",
+    "found",
+    "not_required",
+    "blocked",
+    "confirmed"
+  ],
+  "current_github_review_branch": {
+    "lane": "GitHub review-branch docs",
+    "target": "hvitiswift-afk/nextjs-boilerplate PR #89 branch earth-mesh-receipt-220-deploy-v2",
+    "tool_confirmation": "GitHub commit responses and PR #89",
+    "receipt_range": "221-225",
+    "safe_claim": "review-branch documentation confirmed",
+    "blocked_claim": "main merge, public release, external delivery, official archive, certification, sync, or model release"
+  }
+}

--- a/docs/earth-mesh/receipt-225/seeker-formatter.md
+++ b/docs/earth-mesh/receipt-225/seeker-formatter.md
@@ -1,0 +1,67 @@
+# EARTH-SEEKER-FORMATTER-225
+
+## State
+Review-branch documentation only.
+
+## Purpose
+Receipt 225 makes the five external blockers simple and solvable by turning each missing field into a target that the formatter can seek, fill, verify, and receipt.
+
+The Mario Kart blue-shell image is used only as a private shorthand for a **Seeker Formatter**: a target-seeking checklist that homes in on missing fields inside authorized records. It does not mean tracking people, devices, accounts, private systems, or anything outside authorized scope.
+
+## Five Solvable Targets
+
+| Target ID | Missing field | Seeker question | Solvable input | Completion proof |
+|---|---|---|---|---|
+| T1 | no exact target | Where is the action going? | exact repo, branch, PR, platform, recipient, archive, or sync destination | target recorded |
+| T2 | no final approval phrase | Did JP approve this exact action? | exact final approval phrase naming action, artifact, target, and method | approval recorded |
+| T3 | no source/certification evidence where required | What supports the claim? | source map, review report, certification scope, proof note, or waiver | evidence record |
+| T4 | no external tool confirmation | Did the tool/platform confirm it? | tool response, commit SHA, PR number, receipt, or platform confirmation | confirmation recorded |
+| T5 | no delivery/archive/release/sync receipt | Did the state actually happen? | receipt ID tied to delivery/archive/release/sync state | receipt recorded |
+
+## Seeker Formatter Loop
+
+```text
+1. Select lane.
+2. Extract artifact.
+3. Seek target.
+4. Seek approval phrase.
+5. Seek evidence if required.
+6. Seek tool confirmation.
+7. Seek receipt.
+8. If all five are present, safe claim may upgrade.
+9. If any are missing, claim stays in hold.
+```
+
+## Easy Output
+
+```text
+Lane:
+Artifact:
+T1 Target: missing / found
+T2 Final approval: missing / found
+T3 Evidence: missing / found / not required
+T4 Tool confirmation: missing / found
+T5 Receipt: missing / found
+Current claim: allowed / ready hold / confirmed / blocked
+Next simplest fix:
+```
+
+## Current GitHub Review Branch Example
+
+```text
+Lane: GitHub review-branch docs
+Artifact: docs/earth-mesh receipts 220-225
+T1 Target: found — hvitiswift-afk/nextjs-boilerplate PR #89 branch earth-mesh-receipt-220-deploy-v2
+T2 Final approval: found for Receipt 220 GitHub branch v2; later receipts are expansions on same review branch
+T3 Evidence: not required for documentation-only internal review branch; source/legal certification remains missing for certified claims
+T4 Tool confirmation: found — GitHub commit responses and PR #89
+T5 Receipt: found — receipts 221-225 for review-branch documentation
+Current claim: review-branch documentation confirmed; main merge/public release/external delivery remain blocked
+Next simplest fix: decide whether to keep draft PR, mark ready for review, or continue adding docs
+```
+
+## Safe Claim
+The Seeker Formatter makes missing target/approval/evidence/tool-confirmation/receipt fields explicit and solvable.
+
+## Blocked Claim
+The Seeker Formatter does not perform external scanning, tracking, publication, merge, release, certification, delivery, official archive, app sync, ML release, Gmail action, or phone action.


### PR DESCRIPTION
## Receipt 220 GitHub deployment

This draft PR adds the internal Receipt 220 ontology documentation under `docs/earth-mesh/receipt-220/`.

### Included
- README for Receipt 220
- Far-Seeing Stone Mesh ontology note
- Shadow-Discipline OS governance note with neutral original-safe wording
- Oni Sentinel Restoration note
- Ontology registry JSON
- GitHub deployment QA report

### Boundary
This PR is a review-branch documentation deployment only. It does **not** merge to `main`, publish a production site, submit externally, deliver externally, certify sources or facts, train/deploy ML, sync Obsidian, perform Gmail actions, or perform phone/device actions.

### Receipt state
- GitHub branch created: confirmed
- Docs committed: confirmed
- Draft PR opened: pending by this PR
- Merge/deploy/publish: not performed