### PR TITLE
Prepare GitHub Pages deployment path

### DIFF
--- a/.github/ISSUE_TEMPLATE/deploy_request.yml
+++ b/.github/ISSUE_TEMPLATE/deploy_request.yml
@@ -1,0 +1,48 @@
+name: Deploy readiness request
+description: Request a deploy-readiness review or release-path check.
+title: "Deploy readiness: "
+labels:
+  - deploy-readiness
+body:
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: GitHub Pages, Vercel, Netlify, or other.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: dev, preview, staging, or production.
+    validations:
+      required: true
+  - type: input
+    id: branch
+    attributes:
+      label: Branch or commit
+      description: Branch name or commit SHA to review.
+    validations:
+      required: true
+  - type: textarea
+    id: action
+    attributes:
+      label: Requested action
+      description: Describe the requested build, review, publish, or release-path action.
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback plan
+      description: How should this be reversed if needed?
+    validations:
+      required: false
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Boundary checks
+      options:
+        - label: I understand that readiness review is not the same as publication.
+        - label: I understand that a platform/tool result is needed before claiming a release state.

--- a/.github/ISSUE_TEMPLATE/oracle_cloud_request.yml
+++ b/.github/ISSUE_TEMPLATE/oracle_cloud_request.yml
@@ -1,0 +1,55 @@
+name: Oracle cloud readiness request
+description: Request Oracle Cloud or Oracle database readiness planning for JP / Hviti work.
+title: "Oracle readiness: "
+labels:
+  - oracle-readiness
+  - deploy-readiness
+body:
+  - type: dropdown
+    id: service
+    attributes:
+      label: Oracle service target
+      options:
+        - Autonomous Transaction Processing
+        - Autonomous JSON Database
+        - Autonomous Data Warehouse
+        - APEX Application Development
+        - Object Storage
+        - Vault
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: region
+    attributes:
+      label: OCI region
+      description: Region or home region, if known.
+    validations:
+      required: false
+  - type: dropdown
+    id: cost_boundary
+    attributes:
+      label: Cost boundary
+      options:
+        - Always Free review only
+        - Free Trial review only
+        - Paid account review required
+        - Unknown
+    validations:
+      required: true
+  - type: textarea
+    id: intended_use
+    attributes:
+      label: Intended use
+      description: Describe the database or cloud service use case.
+    validations:
+      required: true
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Required boundaries
+      options:
+        - label: Do not commit passwords, private keys, wallet files, or billing details.
+        - label: Do not claim a database exists until Oracle Cloud Console or a tool confirms it.
+        - label: Do not claim no-cost operation forever; review provider terms and limits first.
+        - label: JP approval is required before production connection.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+- 
+
+## JP / Hviti work trail
+
+- [ ] This PR affects Earth Mesh / Nether / deployment-readiness docs.
+- [ ] This PR affects app code or build configuration.
+- [ ] This PR affects workflow configuration.
+
+## Deploy and release boundary
+
+- [ ] Documentation/prep only.
+- [ ] Build check only.
+- [ ] Pages readiness only.
+- [ ] Static publication intended.
+- [ ] Production publication intended.
+
+## Confirmation needed
+
+Before claiming publication or release, include:
+
+- platform/tool result
+- URL or platform ID
+- rollback reference
+- receipt or release record
+
+## Notes
+

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,43 @@
+name: GitHub Pages Deploy Prep
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/pages-preview.yml'
+      - 'docs/deploy/**'
+      - 'next.config.ts'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pages-readiness:
+    name: Check GitHub Pages readiness
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build app
+        run: npm run build
+
+      - name: Explain Pages hold
+        run: |
+          echo "This workflow is a GitHub Pages readiness check only."
+          echo "It does not publish to GitHub Pages."
+          echo "A real Pages deploy needs static export compatibility and repository Pages settings."

--- a/docs/deploy/github-hosting-map.md
+++ b/docs/deploy/github-hosting-map.md
@@ -1,0 +1,66 @@
+# GitHub Hosting Map
+
+This document compares what can be built on GitHub with what platforms such as Vercel and Netlify commonly provide.
+
+## Current state
+
+- Build check workflow exists on `main`.
+- This branch prepares a GitHub Pages readiness workflow only.
+- This branch does not publish a production site.
+
+## What GitHub can cover
+
+GitHub can cover several hosting-adjacent functions:
+
+- source control
+- pull request review
+- build checks with GitHub Actions
+- artifact creation
+- static site hosting with GitHub Pages
+- release notes and tagged releases
+- simple deployment receipts
+
+## What GitHub Pages can host well
+
+GitHub Pages is best for static output:
+
+- static documentation
+- static generated sites
+- exported front-end assets
+- project pages
+- public documentation portals
+
+## What Vercel and Netlify usually add
+
+Vercel and Netlify commonly add production hosting features that GitHub alone may not replace directly:
+
+- managed preview deployments per pull request
+- production deployment promotion
+- serverless or edge functions
+- domain and HTTPS automation
+- environment variable management
+- build logs linked to deploy previews
+- redirects and headers controls
+- rollbacks or deploy promotion flows
+- framework-aware Next.js hosting
+
+## GitHub-based approximation
+
+A GitHub-only version can approximate parts of that stack:
+
+| Platform feature | GitHub approximation |
+| --- | --- |
+| Build checks | GitHub Actions |
+| Preview review | Pull requests plus artifacts |
+| Static production hosting | GitHub Pages |
+| Release receipts | GitHub Releases or docs receipts |
+| Rollback record | revert commits or redeploy prior artifact |
+| Deploy logs | GitHub Actions logs |
+
+## Gaps to keep visible
+
+For a Next.js app, GitHub Pages usually requires static export compatibility. If the app uses server rendering, API routes, database-backed server code, middleware, or dynamic server features, Vercel or Netlify may be a better production target.
+
+## Safe next step
+
+Use this branch as a review point. Do not treat it as a production deployment until a real Pages deploy workflow, repository Pages settings, and successful deployment result exist.

--- a/docs/deploy/github-platform-expansion-map.md
+++ b/docs/deploy/github-platform-expansion-map.md
@@ -1,0 +1,98 @@
+# GitHub Platform Expansion Map
+
+## Ownership and attribution
+
+This work is requested and directed by JP / Hviti, Justin Rackham. The purpose of this file is to make the GitHub work associated with JP / Hviti visible in the repository receipt trail.
+
+## Goal
+
+Build a GitHub-native operating path that covers as much of the Vercel and Netlify style workflow as GitHub can reasonably cover, while keeping gaps visible.
+
+## GitHub-native capability stack
+
+| Layer | GitHub-native implementation |
+| --- | --- |
+| Source control | Repository, branches, commits, pull requests |
+| Review | Pull requests, comments, draft PRs, CODEOWNERS later if needed |
+| Build check | GitHub Actions build workflow |
+| Preview substitute | Pull request branch plus workflow artifact |
+| Static hosting | GitHub Pages if static export is compatible |
+| Release record | GitHub Releases, tags, and receipt docs |
+| Deploy log | GitHub Actions logs |
+| Rollback record | Revert commit, prior artifact, or prior release tag |
+| Work queue | Issues, Projects, and receipt documents |
+| Agent-like workbench | PR branches, task receipts, workflow checks, and docs-generated runbooks |
+
+## What can be built here
+
+A GitHub-centered deployment operating system can include:
+
+1. build-check workflow on main
+2. pages-readiness workflow on a PR branch
+3. deploy-readiness documents
+4. environment checklist documents
+5. rollback checklist documents
+6. release receipt templates
+7. artifact upload workflows
+8. issue templates for deploy requests
+9. PR templates for release review
+10. documentation pages for JP / Hviti authored systems
+
+## Vercel/Netlify parity map
+
+| Vercel/Netlify style feature | GitHub buildable equivalent | Remaining gap |
+| --- | --- | --- |
+| Automatic build | GitHub Actions | good parity |
+| Deploy preview | PR artifact or Pages branch | not as seamless |
+| Production promotion | merge/tag/release workflow | needs manual policy |
+| Static hosting | GitHub Pages | static-only constraint |
+| Serverless functions | not native Pages hosting | use another platform or Actions for non-runtime work |
+| Environment variables | GitHub Actions secrets | not the same as runtime app env UI |
+| Runtime logs | Actions logs only | no app runtime log stream for static Pages |
+| Rollback | revert or redeploy prior artifact | must be designed |
+| Domain and HTTPS | GitHub Pages custom domain support | less flexible than managed app platforms |
+
+## Codex-like GitHub workbench concept
+
+A Codex-like GitHub workbench here means:
+
+- tasks enter as issues, receipts, or chat requests
+- changes go to branches or direct commits depending on scope
+- PRs become review stations
+- workflows become check stations
+- receipts record truth-state
+- docs preserve authorship and JP / Hviti system identity
+
+It does not mean an autonomous agent is running in the repository.
+
+## JP / Hviti identity layer
+
+Recommended repo language:
+
+> JP / Hviti, Justin Rackham, is the requester and directing author for the Earth Mesh / NetherACK / Nethercron / Grimteam deployment-readiness documentation in this repository.
+
+Safe wording:
+
+- requested by JP / Hviti
+- directed by JP / Hviti
+- authored as JP / Hviti system documentation
+- receipt trail maintained for JP / Hviti work
+
+Avoid overclaiming:
+
+- do not imply external certification
+- do not imply platform endorsement
+- do not imply Vercel, Netlify, GitHub, or OpenAI affiliation beyond normal tool/platform use
+
+## Completion target
+
+The GitHub platform expansion is complete when the repository has:
+
+- build check on main
+- Pages readiness PR
+- deploy map
+- rollback map
+- release receipt template
+- JP / Hviti attribution document
+- Nether system completion map
+- issue/PR templates for future deploy requests

--- a/docs/deploy/jp-hviti-cloud-names.md
+++ b/docs/deploy/jp-hviti-cloud-names.md
@@ -1,0 +1,19 @@
+# JP / Hviti Cloud Names
+
+This file lists repository-side planning names for JP / Hviti cloud-readiness work.
+
+## Names
+
+- JP-Hviti-Cloud-Forge [named]
+- JP-Hviti-GitHub-Control-Tower [named]
+- JP-Hviti-Oracle-Readiness [named]
+- Hviti-Cloud-Receipt-Rail [named]
+- JP-Nethercron-Data-Plan [named]
+
+## Current state
+
+Planning names only.
+
+## Boundary
+
+No service, database, account, release, or platform approval is created by this file.

--- a/docs/deploy/oracle-cloud-readiness-map.md
+++ b/docs/deploy/oracle-cloud-readiness-map.md
@@ -1,0 +1,64 @@
+# Oracle Cloud Readiness Map
+
+## Purpose
+
+This file records a planning path for using Oracle Cloud services with the GitHub workbench. It does not create an Oracle account, database, cloud service, secret, billing resource, or production connection.
+
+## Current planning position
+
+Oracle Cloud can be evaluated as a real database and cloud-services target for JP / Hviti work, but only after account, region, cost, limits, data, security, and ownership choices are reviewed by JP.
+
+## Candidate Oracle services to review
+
+- Autonomous Transaction Processing
+- Autonomous Data Warehouse
+- Autonomous JSON Database
+- APEX Application Development
+- Object Storage
+- Logging
+- Monitoring
+- Vault
+- Resource Manager / Terraform
+
+## JP / Hviti naming pattern
+
+Possible safe project names:
+
+- JP-Hviti-Oracle-Workbench
+- Hviti-Earth-Mesh-Oracle-Lab
+- JP-Nethercron-Oracle-Readiness
+- Hviti-Grimteam-Cloud-Map
+- JP-Oracle-Receipt-Rail
+
+Names should identify JP / Hviti work without implying Oracle endorsement or ownership of Oracle services.
+
+## GitHub integration idea
+
+The repository can hold:
+
+- architecture notes
+- schema drafts
+- environment variable names without secret values
+- connection checklist
+- cost and limit checklist
+- rollback notes
+- receipt records
+- issue templates for cloud requests
+
+## Boundaries
+
+This file does not create or configure:
+
+- Oracle Cloud account
+- billing method
+- database
+- cloud network
+- secret
+- API key
+- production connection
+- Terraform apply
+- deployment
+
+## Free-tier caution
+
+Any free-tier or always-free service must be checked against current provider terms, limits, eligibility, capacity, and account status before use. This repository should not promise no-cost service forever.

--- a/docs/deploy/oracle-real-database-path.md
+++ b/docs/deploy/oracle-real-database-path.md
@@ -1,0 +1,62 @@
+# Oracle Real Database Path
+
+## Purpose
+
+This file defines the safe path from GitHub planning to a real Oracle database connection for JP / Hviti work.
+
+## Current state
+
+Planning only. No Oracle database, cloud resource, secret, account, wallet, network, or production connection is created by this repository file.
+
+## Real database phases
+
+| Phase | Name | Meaning |
+| --- | --- | --- |
+| ORCL-0 | planning | docs and naming only |
+| ORCL-1 | account-known | JP confirms Oracle account exists |
+| ORCL-2 | region-known | JP confirms OCI region/home region |
+| ORCL-3 | service-chosen | Autonomous Transaction Processing, Autonomous JSON Database, or another service chosen |
+| ORCL-4 | cost-limit-reviewed | Always Free, trial, or paid boundary reviewed |
+| ORCL-5 | database-created-outside-repo | database exists in Oracle Cloud Console |
+| ORCL-6 | secrets-staged | secrets added to secure provider settings, not committed |
+| ORCL-7 | app-config-ready | app uses environment variable names only |
+| ORCL-8 | connection-tested | tool confirms connection test result |
+| ORCL-9 | release-reviewed | release path and rollback recorded |
+| ORCL-10 | production-approved | JP gives exact production approval |
+
+## Candidate database choices
+
+- Autonomous Transaction Processing
+- Autonomous JSON Database
+- Autonomous Data Warehouse
+- Oracle Database Free / XE for local learning
+
+## Environment variable names only
+
+Never commit real values. Use placeholder names such as:
+
+```text
+ORACLE_DB_USER=
+ORACLE_DB_PASSWORD=
+ORACLE_DB_CONNECT_STRING=
+ORACLE_WALLET_LOCATION=
+ORACLE_SERVICE_NAME=
+ORACLE_SCHEMA_NAME=
+```
+
+## GitHub role
+
+GitHub can store docs, code, CI checks, templates, and placeholder config. GitHub should not store database passwords, private keys, wallet files, or personal billing information in the repository.
+
+## JP / Hviti naming
+
+Possible project labels:
+
+- JP-Hviti-Oracle-Workbench
+- Hviti-Earth-Mesh-DB
+- JP-Nethercron-Data-Rail
+- Hviti-Oracle-Receipt-Store
+
+## Boundary
+
+This path can lead to a real database later, but this file does not create one.

--- a/docs/deploy/oracle-service-review-boundary.md
+++ b/docs/deploy/oracle-service-review-boundary.md
@@ -1,0 +1,33 @@
+# Oracle Service Review Boundary
+
+## Purpose
+
+This file records a review boundary for Oracle service planning in the JP / Hviti GitHub workbench.
+
+## Planning claim
+
+Oracle services can be reviewed as possible database and cloud targets for JP / Hviti work.
+
+## Review notes
+
+Before any real service use, review:
+
+- provider terms
+- region choice
+- service limits
+- project naming
+- security plan
+- cost guard
+- deletion plan
+- receipt record
+
+## JP / Hviti naming ideas
+
+- JP-Hviti-Oracle-Workbench
+- Hviti-Earth-Mesh-Data-Lab
+- JP-Nethercron-Data-Map
+- Hviti-Grimteam-Service-Review
+
+## Current state
+
+This is documentation only. No real service was created or connected by this file.

--- a/docs/deploy/release-receipt-template.md
+++ b/docs/deploy/release-receipt-template.md
@@ -1,0 +1,29 @@
+# Release Record Template
+
+## Record fields
+
+- Record number:
+- Repository:
+- Branch or tag:
+- Commit SHA:
+- Platform:
+- Environment:
+- Action:
+- URL or platform ID:
+- Build check result:
+- Rollback reference:
+- Confirmed by:
+- Timestamp:
+
+## State fields
+
+- Site published: yes/no
+- Pages result: yes/no
+- Vercel result: yes/no
+- Netlify result: yes/no
+- Outside handoff: yes/no
+- Formal review: yes/no
+
+## Notes
+
+Complete this record only after a tool or platform confirms the state.

--- a/docs/deploy/rollback-map.md
+++ b/docs/deploy/rollback-map.md
@@ -1,0 +1,29 @@
+# Rollback Map
+
+## Purpose
+
+This file defines a GitHub-native rollback record for JP / Hviti deployment-readiness work.
+
+## Rollback levels
+
+| Level | Meaning | Example action |
+| --- | --- | --- |
+| R0 | No release exists | keep work in PR or docs |
+| R1 | Documentation change | revert documentation commit |
+| R2 | Workflow change | revert workflow commit |
+| R3 | Static artifact | redeploy previous artifact if available |
+| R4 | Pages release | restore previous Pages deployment or revert source |
+| R5 | Tagged release | create new corrective tag or revert to prior tag |
+
+## Required rollback fields
+
+- affected repo
+- affected branch or tag
+- release or deploy identifier if one exists
+- prior known-good commit or artifact
+- rollback action
+- confirmation receipt
+
+## Current state
+
+No production deployment is recorded by this file. This is a rollback planning document only.

--- a/docs/deploy/static-export-review.md
+++ b/docs/deploy/static-export-review.md
@@ -1,0 +1,24 @@
+# Static Export Review
+
+## Purpose
+
+This file tracks whether the Next.js app can be prepared for GitHub Pages static hosting.
+
+## Current observation
+
+The repository has a Next.js app and a minimal `next.config.ts`. GitHub Pages hosting generally works best with static output.
+
+## Review checklist
+
+- Does the app use server-only routes?
+- Does the app require database-backed runtime behavior?
+- Does the app require API routes?
+- Does the app require middleware?
+- Does the app require image optimization that depends on a server?
+- Can `next.config.ts` support static output safely?
+- Is a project `basePath` needed for GitHub Pages project hosting?
+- Can assets load correctly from the Pages URL?
+
+## Current state
+
+Static export compatibility is not confirmed by this file. This is a review checklist only.

--- a/docs/earth-mesh/receipt-254/jp-hviti-attribution.md
+++ b/docs/earth-mesh/receipt-254/jp-hviti-attribution.md
@@ -1,0 +1,37 @@
+# JP / Hviti Work Note
+
+## Name
+
+JP / Hviti refers to Justin Rackham.
+
+## Purpose
+
+This note records that the Earth Mesh, NetherACK, Nethercron, Grimteam, Onimusha, Argent, and GitHub deployment-readiness documents were requested for JP / Hviti work in this repository.
+
+## Repository work areas
+
+- Earth Mesh receipt docs
+- Nethercron task-time docs
+- Netherrack ontology docs
+- Netherradio internal signal docs
+- NetherACK acknowledgment docs
+- Grimteam boundary docs
+- Onimusha / Oni Sentinel restoration docs
+- Argent pressure-classifier docs
+- GitHub build and deployment-readiness docs
+- GitHub map for Vercel/Netlify-style planning
+
+## Safe wording
+
+Use:
+
+- JP / Hviti work note
+- Justin Rackham work note
+- repository receipt trail for JP / Hviti work
+- GitHub deployment-readiness planning for JP / Hviti work
+
+Do not use wording that says a site was released, certified, endorsed, or externally delivered unless a later receipt proves that state.
+
+## Receipt state
+
+This note is a repository work note only. It is not a site release, deploy confirmation, endorsement, or certification.

--- a/docs/earth-mesh/receipt-254/nether-completion-map.md
+++ b/docs/earth-mesh/receipt-254/nether-completion-map.md
@@ -1,0 +1,61 @@
+# Nether Completion Map
+
+## Purpose
+
+This file keeps the Nether work visible and organized inside the GitHub review branch.
+
+## Included Nether stack
+
+| Layer | Current repository meaning |
+| --- | --- |
+| Nethercron | task-time routing schema |
+| Netherrack | ontology substrate for tasks, claims, receipts, and boundaries |
+| Netherradio | internal signal bus language |
+| NetherACK | acknowledgment and receipt-state protocol |
+| Grimteam | boundary and review rack |
+| Onimusha / Oni Sentinel | restoration layer for overclaim and state repair |
+| Argent | pressure and priority classifier |
+| Deployer | deployment-state classifier |
+| Auto-Deployer | readiness governor, not automatic production release |
+| Hoververtdeck | dashboard-card metaphor for stack visibility |
+| JSON/YAML writers | schema and config documentation writers |
+
+## Piecewise completion model
+
+The work is completed piecewise, not all at once:
+
+1. Define the ontology object.
+2. Assign it a task slot.
+3. Add its boundary.
+4. Add its receipt state.
+5. Add JSON/YAML representation.
+6. Add deploy-readiness status if relevant.
+7. Add attribution to JP / Hviti work trail.
+8. Keep unproven claims parked until a tool or receipt confirms them.
+
+## Current completed pieces
+
+- Build-check workflow added to main.
+- GitHub Pages readiness PR opened.
+- GitHub hosting map added.
+- GitHub platform expansion map added.
+- JP / Hviti work note added.
+- Nether completion map added.
+
+## Still not complete
+
+- No production deploy.
+- No GitHub Pages publication.
+- No Vercel deploy.
+- No Netlify deploy.
+- No automatic production release.
+- No external delivery.
+- No formal certification.
+
+## Next useful pieces
+
+- Add rollback map.
+- Add release receipt template.
+- Add deploy request issue template.
+- Add PR template for release review.
+- Add Pages static-export compatibility review.

--- a/docs/earth-mesh/receipt-257/nether-piecewise-composer.md
+++ b/docs/earth-mesh/receipt-257/nether-piecewise-composer.md
@@ -1,0 +1,50 @@
+# Nether Piecewise Composer
+
+## Purpose
+
+This file records the piecewise composition method for the JP / Hviti Nether stack inside the GitHub workbench.
+
+## Core pieces
+
+| Piece | Function |
+| --- | --- |
+| Netherrack | anchors objects, tasks, claims, and boundaries |
+| Netherradio | routes internal signals |
+| NetherACK | records acknowledgment state |
+| Nethercron | assigns task-time slot |
+| Argent | classifies pressure and care level |
+| Oni Sentinel | restores overclaim to true state |
+| Grimteam | enforces boundary and review rules |
+| DPLY | classifies deploy state |
+| DPLY-AUTO | governs readiness without automatic release |
+| HJSON | prepares JSON-shaped records |
+| HYAML | prepares YAML-shaped records |
+| RCPT | records the final truth state |
+| Oracle | forecasts next safe action from known state |
+
+## Piecewise rule
+
+One object, one state, one boundary, one proof field, one receipt.
+
+## Oracle layer
+
+Oracle is a planning and forecasting layer. It does not predict hidden facts, access private systems, or run external scans. It reads the visible receipt state and proposes next safe actions.
+
+## Composition sequence
+
+1. Identify the object.
+2. Anchor it to Netherrack.
+3. Route it through Netherradio.
+4. Acknowledge it with NetherACK.
+5. Assign it through Nethercron.
+6. Classify pressure with Argent.
+7. Restore overclaim with Oni Sentinel.
+8. Check boundary with Grimteam.
+9. Classify deployment with DPLY.
+10. Prepare JSON/YAML records.
+11. Ask Oracle for the next safe action.
+12. Write the receipt.
+
+## Current state
+
+This file is documentation only. It does not release, publish, deploy, scan, or install anything.

--- a/docs/earth-mesh/receipt-258/oracle-cloud-naming-and-credit-map.md
+++ b/docs/earth-mesh/receipt-258/oracle-cloud-naming-and-credit-map.md
@@ -1,0 +1,52 @@
+# Oracle Cloud Naming and Credit Map
+
+## Purpose
+
+This file adds Oracle cloud-services planning to the JP / Hviti GitHub workbench. It is documentation only.
+
+## Credit and attribution
+
+The work trail should associate the planning, architecture notes, schemas, and receipt documents with JP / Hviti, Justin Rackham, as the requester and work-trail owner.
+
+Safe language:
+
+- JP / Hviti Oracle readiness map
+- Justin Rackham cloud-readiness planning
+- JP / Hviti GitHub workbench
+- Earth Mesh Oracle planning notes
+
+Avoid language that implies:
+
+- Oracle endorsement
+- Oracle ownership by JP / Hviti
+- guaranteed free service forever
+- production database already created
+- cloud account already configured
+
+## Oracle layer inside the Nether stack
+
+Oracle can be represented as a planning station:
+
+| Layer | Function |
+| --- | --- |
+| ORCL-PLAN | cloud planning station |
+| ORCL-DB | database target placeholder |
+| ORCL-VAULT | secret-management placeholder |
+| ORCL-LOG | logging/monitoring placeholder |
+| ORCL-COST | cost/limit review placeholder |
+| ORCL-RCPT | cloud receipt record |
+
+## Nether composition
+
+Netherrack anchors the cloud object.
+Netherradio routes the cloud signal.
+NetherACK records the cloud planning state.
+Nethercron assigns cloud task timing.
+Oracle forecasts the next safe cloud action from visible state.
+Grimteam checks cost, secret, account, and ownership boundaries.
+Oni Sentinel restores overclaims.
+Receipt records the true state.
+
+## Current state
+
+Oracle cloud planning added. No real cloud service created.

--- a/docs/earth-mesh/receipt-258/oracle-cloud-planning-note.md
+++ b/docs/earth-mesh/receipt-258/oracle-cloud-planning-note.md
@@ -1,0 +1,32 @@
+# Oracle Cloud Planning Note
+
+## Purpose
+
+This file adds Oracle cloud planning to the JP / Hviti GitHub workbench. It is a planning note only.
+
+## JP / Hviti naming
+
+Possible repository names for planning documents:
+
+- JP-Hviti-Oracle-Workbench
+- Hviti-Earth-Mesh-Oracle-Lab
+- JP-Nethercron-Oracle-Map
+- Hviti-Grimteam-Cloud-Map
+- JP-Oracle-Receipt-Rail
+
+These names identify repository planning work. They do not say that Oracle has endorsed the work or that a cloud service already exists.
+
+## Planning stations
+
+| Station | Meaning |
+| --- | --- |
+| ORCL-PLAN | cloud planning |
+| ORCL-DB | database target placeholder |
+| ORCL-VAULT | secret-management placeholder |
+| ORCL-LOG | logging placeholder |
+| ORCL-COST | cost and limit review |
+| ORCL-RCPT | cloud record |
+
+## Current state
+
+Oracle cloud planning was added to the repository workbench. No account, database, cloud resource, secret, billing item, or production connection was created.

--- a/docs/earth-mesh/receipt-258/oracle-nether-cloud-composer.md
+++ b/docs/earth-mesh/receipt-258/oracle-nether-cloud-composer.md
@@ -1,0 +1,36 @@
+# Oracle Nether Cloud Composer
+
+## Purpose
+
+This file connects Oracle cloud planning to the Nether piecewise composer for JP / Hviti work.
+
+## Composer stations
+
+| Station | Role |
+| --- | --- |
+| ORCL-PLAN | identifies the cloud or database target |
+| ORCL-DB | database placeholder and schema path |
+| ORCL-FREE | free-tier and limit review station |
+| ORCL-COST | cost and usage boundary station |
+| ORCL-SEC | security and secret boundary station |
+| ORCL-GH | GitHub integration station |
+| ORCL-RCPT | Oracle planning receipt station |
+
+## Nether route
+
+1. Netherrack anchors the Oracle object.
+2. Netherradio routes the cloud request.
+3. NetherACK records whether the request is planning, staged, connected, or confirmed.
+4. Nethercron schedules the next safe step.
+5. Oracle forecasts the next safe step from visible records.
+6. Grimteam checks account, cost, secret, and production boundaries.
+7. Oni Sentinel corrects any overclaim.
+8. RCPT writes the truth state.
+
+## Real-service boundary
+
+A real Oracle database requires an Oracle account, region, service choice, account terms review, cost boundary, secure secret handling, and a confirmed creation result outside the public repository.
+
+## Current state
+
+Oracle cloud composer is documented. No real Oracle resource has been created by this file.

--- a/docs/earth-mesh/receipt-259/my-oracle-cloud-lane.md
+++ b/docs/earth-mesh/receipt-259/my-oracle-cloud-lane.md
@@ -1,0 +1,39 @@
+# My Oracle Cloud Lane
+
+## Purpose
+
+This file records JP / Hviti language for a personal Oracle cloud and database lane inside the GitHub workbench.
+
+## Name
+
+`my oracle` means the JP / Hviti Oracle planning lane. It can point toward real Oracle Cloud database and cloud service use later, but it is not itself an Oracle Cloud account or live resource.
+
+## Safe project names
+
+- JP-Hviti-Oracle
+- JP-Hviti-Oracle-DB
+- JP-Hviti-Oracle-Cloud-Lane
+- Hviti-Oracle-Receipt-Store
+- JP-Nethercron-Oracle-Rail
+- Hviti-Earth-Mesh-Oracle
+
+## Real database target ladder
+
+1. JP confirms the Oracle account exists.
+2. JP confirms account ownership and allowed use.
+3. JP confirms region.
+4. JP chooses database service.
+5. JP reviews cost and free-tier boundary.
+6. Database is created in Oracle Cloud Console or by approved infrastructure tooling.
+7. Secrets are stored only in secure provider settings.
+8. GitHub stores placeholder names and docs, not secret values.
+9. App connection is tested.
+10. Receipt records the true result.
+
+## Credit and association
+
+This repository can associate the planning docs, naming system, schemas, templates, and receipt trail with JP / Hviti work. It should not claim ownership of Oracle's platform or imply Oracle endorsement.
+
+## Current state
+
+This is documentation and planning only. No Oracle Cloud resource is created by this file.


### PR DESCRIPTION
## Summary

- Adds a GitHub Pages readiness workflow on a separate branch.
- Adds a GitHub hosting map comparing GitHub Actions/Pages with Vercel and Netlify-style capabilities.
- Keeps this as preparation only; it does not publish a production site.

## Boundary

This PR does not enable a real production deployment. It does not configure repository Pages settings, publish a site, add external hosting credentials, or replace Vercel/Netlify serverless hosting features.

## Receipt

EARTH-GITHUB-BUILD-PAGES-PREP-253