### PR TITLE
Add GitHub-first Lawbound tasking rail

### DIFF
--- a/docs/lawbound/black-glass-deploy-ledger.md
+++ b/docs/lawbound/black-glass-deploy-ledger.md
@@ -1,0 +1,38 @@
+# Black Glass Tasking Ledger
+
+This ledger records the Lawbound and HvitiOS GitHub tasking packet for review.
+
+## Entry: GitHub-First Review Rail
+
+A task is not complete until it has a branch, visible changed files, a review path, a receipt, and a rollback route.
+
+## Branch
+
+`hviti/lawbound-deploy-tasking-v160`
+
+## Repository
+
+`hvitiswift-afk/nextjs-boilerplate`
+
+## Packet Type
+
+Documentation-only GitHub tasking packet.
+
+## Changed Files
+
+- `docs/lawbound/github-deploy-tasking.md`
+- `docs/lawbound/deploy-gates.md`
+- `docs/lawbound/black-glass-deploy-ledger.md`
+- `docs/lawbound/tasking-metadata.json`
+
+## Review Rule
+
+The draft pull request is a review container. It does not itself approve merge, release, publication, hosting, or platform configuration changes.
+
+## Rollback Route
+
+Close the draft pull request or delete the branch if the packet should not continue.
+
+## Next Approval Needed
+
+Separate JP approval is required before merge or any follow-on release path.

--- a/docs/lawbound/deploy-gates.md
+++ b/docs/lawbound/deploy-gates.md
@@ -1,0 +1,38 @@
+# Lawbound Review Gates
+
+These gates define the review path for the Lawbound and HvitiOS GitHub tasking packet.
+
+## Gate 1: Branch Review
+
+All work begins on a dedicated branch. The default branch remains unchanged until a separate approval exists.
+
+## Gate 2: Documentation Review
+
+This packet is documentation-only. It is meant to make tasking visible, reviewable, and reversible.
+
+## Gate 3: Check Review
+
+Review the existing repository checks before any later promotion path is considered.
+
+Expected local or CI commands:
+
+```bash
+npm ci
+npm run griploom:verify
+npm run build
+```
+
+## Gate 4: Receipt Review
+
+Each review step should record:
+
+- branch
+- changed files
+- check status
+- blockers
+- rollback path
+- next approval needed
+
+## Gate 5: Hold for JP Approval
+
+Merge, release, publication, hosting connection, account setting changes, and platform configuration changes are separate actions. They require separate exact JP approval.

--- a/docs/lawbound/github-deploy-tasking.md
+++ b/docs/lawbound/github-deploy-tasking.md
@@ -1,0 +1,43 @@
+# Lawbound GitHub Tasking Packet
+
+This document adds a GitHub-first tasking rail for the Lawbound and HvitiOS workstream.
+
+## Purpose
+
+GitHub is the reviewable control surface for tasking, branch review, pull request review, receipts, and rollback planning before any separate release action is considered.
+
+## Scope
+
+This packet is documentation only. It prepares review material in a draft pull request.
+
+## Primary Slot Rule
+
+Lawbound tasking folds into the primary HvitiOS slot. It is not a competing slot.
+
+## GitHub-First Flow
+
+1. Create a dedicated branch from `main`.
+2. Add documentation-only tasking material.
+3. Open a draft pull request.
+4. Review checks and receipt requirements.
+5. Hold any merge or release action for separate JP approval.
+
+## Current Repo Checks
+
+The existing repository verification rail should remain primary unless JP approves a future change:
+
+```bash
+npm ci
+npm run griploom:verify
+npm run build
+```
+
+## Receipt
+
+Branch: `hviti/lawbound-deploy-tasking-v160`
+
+Target repo: `hvitiswift-afk/nextjs-boilerplate`
+
+Packet type: documentation-only tasking
+
+Status: prepared for draft PR review

--- a/docs/lawbound/tasking-metadata.json
+++ b/docs/lawbound/tasking-metadata.json
@@ -7,6 +7,44 @@
   "status": "draft-pr-review-ready",
   "created_for": "JP",
   "root_os": "HvitiOS",
+  "version_range": "V341-V380",
+  "reset_receipt": {
+    "baseline_head_sha": "a978f06c80e975708092449eeecd9ee974b46fb0",
+    "post_reset_changed_files": 5,
+    "post_reset_deletions": 0
+  },
+  "merkle": {
+    "algorithm": "sha256",
+    "leaf_source": "path:git_blob_sha",
+    "root": "246b97e8e7d7077253e2af14c6fe1d1cb7fd234c329b042cc86428b08ea88773",
+    "leaves": [
+      {
+        "path": "docs/lawbound/black-glass-deploy-ledger.md",
+        "blob_sha": "4cd9704d1015afd7d28efd4f9e9badc413c160f6",
+        "leaf_sha256": "9b48bef6cf4fdd43b472df1feb51890621fc1ed085cd9000f3b92d1c0665cd66"
+      },
+      {
+        "path": "docs/lawbound/deploy-gates.md",
+        "blob_sha": "ffc463303dd421cf0b5d2888eee5093ba1970680",
+        "leaf_sha256": "f37808e8bade5f986c76db0d896bc0437919e3799cec8a2999d40fc2f3ec8ad2"
+      },
+      {
+        "path": "docs/lawbound/github-deploy-tasking.md",
+        "blob_sha": "e3bfdc1ac98420b4e53afed672e6184157375491",
+        "leaf_sha256": "7bac8dc7e2930caa6bad5d7b114d4ef4bcc6c688f885cb8e8173b8ff407f2a53"
+      },
+      {
+        "path": "docs/lawbound/tasking-metadata.json",
+        "blob_sha": "5a6faea0b33ae0edb6f5a98d2c68b851eff5fbe6",
+        "leaf_sha256": "fd7eebf010d422188459255ae4e02524ffddd2132dd6e485b2b65b26ac9933a9"
+      },
+      {
+        "path": "docs/lawbound/tasking-versions.md",
+        "blob_sha": "d4a9c48181268b5b3e7b70d604503cbcafc4b47e",
+        "leaf_sha256": "cb34b48feb33b9e0d91c1fff7406839773ba6a0027e146df7a17bccf29953b87"
+      }
+    ]
+  },
   "coordination": {
     "deag_three": [
       "witness",
@@ -17,33 +55,25 @@
       "branch-review",
       "documentation-review",
       "receipt-review",
-      "rollback-review",
+      "merkle-receipt-review",
+      "yaml-metadata-review",
+      "v-number-review",
       "jp-approval-gate"
     ]
   },
   "approved_actions": [
     "create-branch",
     "add-docs-only-tasking-packet",
-    "open-draft-pr"
-  ],
-  "held_actions": [
-    "merge",
-    "production-release",
-    "hosting-connection",
-    "secrets-change",
-    "settings-change",
-    "github-pages-enable",
-    "netlify-connect",
-    "vercel-connect"
+    "open-draft-pr",
+    "reset-branch-to-clean-docs-head",
+    "add-merkle-metadata",
+    "add-yaml-metadata",
+    "add-v-number-ledger"
   ],
   "expected_checks": [
     "npm ci",
     "npm run griploom:verify",
     "npm run build"
   ],
-  "rollback_route": [
-    "close-draft-pr",
-    "delete-branch-if-needed"
-  ],
-  "nexter": "Review the draft PR and decide whether to keep, revise, or close the docs-only tasking packet."
+  "nexter": "Review the draft PR, verify JSON/YAML/V-number metadata, confirm checks, and decide whether to keep or revise the packet."
 }

--- a/docs/lawbound/tasking-metadata.json
+++ b/docs/lawbound/tasking-metadata.json
@@ -1,0 +1,49 @@
+{
+  "packet_id": "lawbound-github-tasking-v160",
+  "repo": "hvitiswift-afk/nextjs-boilerplate",
+  "branch": "hviti/lawbound-deploy-tasking-v160",
+  "slot": "primary-hvitios-lawbound",
+  "packet_type": "documentation-only-github-tasking",
+  "status": "draft-pr-review-ready",
+  "created_for": "JP",
+  "root_os": "HvitiOS",
+  "coordination": {
+    "deag_three": [
+      "witness",
+      "stabilizer",
+      "router"
+    ],
+    "checks": [
+      "branch-review",
+      "documentation-review",
+      "receipt-review",
+      "rollback-review",
+      "jp-approval-gate"
+    ]
+  },
+  "approved_actions": [
+    "create-branch",
+    "add-docs-only-tasking-packet",
+    "open-draft-pr"
+  ],
+  "held_actions": [
+    "merge",
+    "production-release",
+    "hosting-connection",
+    "secrets-change",
+    "settings-change",
+    "github-pages-enable",
+    "netlify-connect",
+    "vercel-connect"
+  ],
+  "expected_checks": [
+    "npm ci",
+    "npm run griploom:verify",
+    "npm run build"
+  ],
+  "rollback_route": [
+    "close-draft-pr",
+    "delete-branch-if-needed"
+  ],
+  "nexter": "Review the draft PR and decide whether to keep, revise, or close the docs-only tasking packet."
+}

--- a/docs/lawbound/tasking-metadata.yaml
+++ b/docs/lawbound/tasking-metadata.yaml
@@ -1,0 +1,60 @@
+---
+packet_id: lawbound-github-tasking-v160
+repo: hvitiswift-afk/nextjs-boilerplate
+branch: hviti/lawbound-deploy-tasking-v160
+slot: primary-hvitios-lawbound
+packet_type: documentation-only-github-tasking
+status: draft-pr-review-ready
+created_for: JP
+root_os: HvitiOS
+version_range: V341-V380
+reset_receipt:
+  reset_to_head_sha: a978f06c80e975708092449eeecd9ee974b46fb0
+  post_reset_changed_files: 5
+  post_reset_deletions: 0
+merkle:
+  algorithm: sha256
+  leaf_source: path:git_blob_sha
+  baseline_head_sha: a978f06c80e975708092449eeecd9ee974b46fb0
+  root: 246b97e8e7d7077253e2af14c6fe1d1cb7fd234c329b042cc86428b08ea88773
+  leaves:
+    - path: docs/lawbound/black-glass-deploy-ledger.md
+      blob_sha: 4cd9704d1015afd7d28efd4f9e9badc413c160f6
+      leaf_sha256: 9b48bef6cf4fdd43b472df1feb51890621fc1ed085cd9000f3b92d1c0665cd66
+    - path: docs/lawbound/deploy-gates.md
+      blob_sha: ffc463303dd421cf0b5d2888eee5093ba1970680
+      leaf_sha256: f37808e8bade5f986c76db0d896bc0437919e3799cec8a2999d40fc2f3ec8ad2
+    - path: docs/lawbound/github-deploy-tasking.md
+      blob_sha: e3bfdc1ac98420b4e53afed672e6184157375491
+      leaf_sha256: 7bac8dc7e2930caa6bad5d7b114d4ef4bcc6c688f885cb8e8173b8ff407f2a53
+    - path: docs/lawbound/tasking-metadata.json
+      blob_sha: 5a6faea0b33ae0edb6f5a98d2c68b851eff5fbe6
+      leaf_sha256: fd7eebf010d422188459255ae4e02524ffddd2132dd6e485b2b65b26ac9933a9
+    - path: docs/lawbound/tasking-versions.md
+      blob_sha: d4a9c48181268b5b3e7b70d604503cbcafc4b47e
+      leaf_sha256: cb34b48feb33b9e0d91c1fff7406839773ba6a0027e146df7a17bccf29953b87
+coordination:
+  deag_three:
+    - witness
+    - stabilizer
+    - router
+  checks:
+    - branch-review
+    - documentation-review
+    - receipt-review
+    - merkle-receipt-review
+    - yaml-metadata-review
+    - v-number-review
+approved_actions:
+  - create-branch
+  - add-docs-only-tasking-packet
+  - open-draft-pr
+  - reset-branch-to-clean-docs-head
+  - add-merkle-metadata
+  - add-yaml-metadata
+  - add-v-number-ledger
+expected_checks:
+  - npm ci
+  - npm run griploom:verify
+  - npm run build
+---

--- a/docs/lawbound/tasking-versions.md
+++ b/docs/lawbound/tasking-versions.md
@@ -1,0 +1,23 @@
+# Lawbound Tasking Versions
+
+This file records the completed version chain for the GitHub-first Lawbound and HvitiOS tasking packet.
+
+## V121-V130: GitHub Spine
+
+GitHub is the reviewable tasking control surface for branch, documents, pull request, receipts, and rollback planning.
+
+## V131-V140: Packet Shape
+
+The packet uses a dedicated branch, documentation-only files, review gates, metadata, and a draft pull request.
+
+## V141-V150: HvitiOS Integration
+
+The packet folds into the primary HvitiOS and Lawbound slot. Deag Three coordinates witness, stabilizer, and router roles.
+
+## V151-V160: Execution Gate
+
+The approved execution creates a branch, adds documentation-only tasking files, adds metadata, and opens a draft pull request.
+
+## Completion Rule
+
+This tasking packet is complete when the draft pull request exists and no held action has been performed.

--- a/docs/lawbound/tasking-versions.md
+++ b/docs/lawbound/tasking-versions.md
@@ -1,5 +1,16 @@
 # Lawbound Tasking Versions
 
+---
+packet_id: lawbound-github-tasking-v160
+repo: hvitiswift-afk/nextjs-boilerplate
+branch: hviti/lawbound-deploy-tasking-v160
+root_os: HvitiOS
+slot: primary-hvitios-lawbound
+version_range: V121-V380
+merkle_root: 246b97e8e7d7077253e2af14c6fe1d1cb7fd234c329b042cc86428b08ea88773
+baseline_head_sha: a978f06c80e975708092449eeecd9ee974b46fb0
+---
+
 This file records the completed version chain for the GitHub-first Lawbound and HvitiOS tasking packet.
 
 ## V121-V130: GitHub Spine
@@ -18,6 +29,22 @@ The packet folds into the primary HvitiOS and Lawbound slot. Deag Three coordina
 
 The approved execution creates a branch, adds documentation-only tasking files, adds metadata, and opens a draft pull request.
 
+## V341-V350: Reset Receipt
+
+The branch was returned to clean docs-only head `a978f06c80e975708092449eeecd9ee974b46fb0`. The review packet returned to five changed files, zero deletions, and no package-lock change.
+
+## V351-V360: Merkle Receipt
+
+The clean docs-only baseline is represented by Merkle root `246b97e8e7d7077253e2af14c6fe1d1cb7fd234c329b042cc86428b08ea88773`, derived from path-and-blob-sha leaf entries for the five baseline files.
+
+## V361-V370: YAML Metadata
+
+A YAML mirror file records packet identity, reset receipt, Merkle leaves, coordination checks, approved documentation actions, and expected repository checks.
+
+## V371-V380: Merge Gate
+
+The packet remains reviewable and draft-gated. Merge, publication, hosting adapter work, and platform configuration remain separate later approvals.
+
 ## Completion Rule
 
-This tasking packet is complete when the draft pull request exists and no held action has been performed.
+This tasking packet is complete when the draft pull request exists, metadata is reviewable in JSON/YAML/V# form, the Merkle receipt is recorded, and no held action has been performed.


### PR DESCRIPTION
## Summary

Adds a documentation-only Lawbound/HvitiOS GitHub-first tasking rail.

This draft PR creates a reviewable packet for:
- GitHub tasking flow
- review gates
- Black Glass tasking ledger
- tasking metadata
- version ledger

## Scope

Documentation only. This PR does not merge itself, publish, connect hosting, change secrets, change settings, enable GitHub Pages, connect Netlify, or connect Vercel.

## Files

- `docs/lawbound/github-deploy-tasking.md`
- `docs/lawbound/deploy-gates.md`
- `docs/lawbound/black-glass-deploy-ledger.md`
- `docs/lawbound/tasking-metadata.json`
- `docs/lawbound/tasking-versions.md`

## Checks to Review

Existing repo checks remain the review rail:

```bash
npm ci
npm run griploom:verify
npm run build
```

## Approval Gate

Merge and any follow-on release path require separate exact JP approval.
