### PR TITLE
Add public Norstein bridge rail

### DIFF
--- a/.github/workflows/norstein-public-bridge.yml
+++ b/.github/workflows/norstein-public-bridge.yml
@@ -1,0 +1,28 @@
+name: Verify Norstein Public Bridge
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "docs/NORSTEIN-PUBLIC-BRIDGE.md"
+      - "examples/norstein-public-bridge.json"
+      - "scripts/check-norstein-public-bridge.mjs"
+      - "package.json"
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "docs/NORSTEIN-PUBLIC-BRIDGE.md"
+      - "examples/norstein-public-bridge.json"
+      - "scripts/check-norstein-public-bridge.mjs"
+      - "package.json"
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm run norstein:public:check

--- a/.github/workflows/norstein-public-bridge.yml
+++ b/.github/workflows/norstein-public-bridge.yml
@@ -5,16 +5,16 @@ on:
       - "README.md"
       - "docs/NORSTEIN-PUBLIC-BRIDGE.md"
       - "examples/norstein-public-bridge.json"
+      - "examples/norstein-github-capability.json"
       - "scripts/check-norstein-public-bridge.mjs"
-      - "package.json"
   push:
     branches: [main]
     paths:
       - "README.md"
       - "docs/NORSTEIN-PUBLIC-BRIDGE.md"
       - "examples/norstein-public-bridge.json"
+      - "examples/norstein-github-capability.json"
       - "scripts/check-norstein-public-bridge.mjs"
-      - "package.json"
 permissions:
   contents: read
 jobs:
@@ -25,4 +25,4 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm run norstein:public:check
+      - run: node scripts/check-norstein-public-bridge.mjs

--- a/README.md
+++ b/README.md
@@ -558,3 +558,25 @@ Verify, deploy, open, score, tick, verify.
 - `.github/workflows/griploom-verify.yml`
 
 Verified credits in. Production geometry out.
+
+
+---
+
+# Norstein Public Bridge
+
+This public rail connects the existing Goblin/GRIPLOOM repository to JP's public Norstein Nexus while the canonical source repository remains private.
+
+- Public Nexus: https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site
+- Public campaign: https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site/campaign
+- Public X authority: https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site/nexus/entries
+- Private canonical source: `hvitiswift-afk/Norstein-Bekkler` (identity only; private contents are not mirrored here)
+
+The bridge publishes only approved public metadata. It contains no secrets, credentials, donor records, private-person records, payment execution, Meta posting, or app-store submission authority.
+
+Validate the rail with:
+
+```bash
+npm run norstein:public:check
+```
+
+See `docs/NORSTEIN-PUBLIC-BRIDGE.md` and `examples/norstein-public-bridge.json`.

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ The bridge publishes only approved public metadata. It contains no secrets, cred
 Validate the rail with:
 
 ```bash
-npm run norstein:public:check
+node scripts/check-norstein-public-bridge.mjs
 ```
 
-See `docs/NORSTEIN-PUBLIC-BRIDGE.md` and `examples/norstein-public-bridge.json`.
+See `docs/NORSTEIN-PUBLIC-BRIDGE.md`, `examples/norstein-public-bridge.json`, and `examples/norstein-github-capability.json`. Y owns the connected public/private GitHub rail; Z expands verified private automation; XYZ runs both through X.

--- a/docs/NORSTEIN-PUBLIC-BRIDGE.md
+++ b/docs/NORSTEIN-PUBLIC-BRIDGE.md
@@ -10,4 +10,21 @@ Allowed here: public project identity, public Nexus links, public fundraiser ter
 
 Not allowed here: passwords, tokens, credentials, donor identities, payout/bank data, private-person records, payment execution, private source snapshots, Meta publishing authority, or app-store submission authority.
 
-Run `npm run norstein:public:check` before merging changes to this rail.
+Run `node scripts/check-norstein-public-bridge.mjs` before merging changes to this rail.
+
+
+## Connected GitHub capability — Y
+
+Y connects this public repository to the private canonical Norstein repository. Public-safe metadata moves through classify → redact private-only material → verify → public PR → checks → merge receipt. Private implementation never automatically mirrors into public.
+
+## Expanded authorization — Z
+
+Z authorizes repository discovery, branches, file updates, pull requests, workflow inspection, and merging after passing checks. Repository creation, visibility changes, secret access, wholesale private-source mirroring, and release publication remain separately gated.
+
+## XYZ.improved
+
+X orchestrates Y and Z with checks, receipts, and rollback required. Validate without installing dependencies:
+
+```bash
+node scripts/check-norstein-public-bridge.mjs
+```

--- a/docs/NORSTEIN-PUBLIC-BRIDGE.md
+++ b/docs/NORSTEIN-PUBLIC-BRIDGE.md
@@ -1,0 +1,13 @@
+# Norstein public bridge
+
+This repository is the public GitHub rail for Norstein, integrated into the existing Goblin/GRIPLOOM system. The full public Nexus and campaign are linked from the machine-readable bridge record.
+
+The canonical Norstein source remains in the private `hvitiswift-afk/Norstein-Bekkler` repository. This public rail records its identity and verified public relationship without copying private source or private records.
+
+## Public boundary
+
+Allowed here: public project identity, public Nexus links, public fundraiser terms, non-secret checks, and public release documentation.
+
+Not allowed here: passwords, tokens, credentials, donor identities, payout/bank data, private-person records, payment execution, private source snapshots, Meta publishing authority, or app-store submission authority.
+
+Run `npm run norstein:public:check` before merging changes to this rail.

--- a/examples/norstein-github-capability.json
+++ b/examples/norstein-github-capability.json
@@ -1,0 +1,50 @@
+{
+  "schema": "jp.github.capability.yz.v1",
+  "capabilityId": "GITHUB-YZ-20260711-001",
+  "account": "hvitiswift-afk",
+  "Y": {
+    "role": "connected-public-private-rail",
+    "public": {
+      "repository": "hvitiswift-afk/nextjs-boilerplate",
+      "visibility": "public",
+      "purpose": "public-safe Norstein identity, documentation, campaign links, receipts"
+    },
+    "private": {
+      "repository": "hvitiswift-afk/Norstein-Bekkler",
+      "visibility": "private",
+      "purpose": "canonical source, implementation, artifacts, release packets"
+    },
+    "promotion": [
+      "classify change",
+      "remove private-only material",
+      "verify public boundary",
+      "open public PR",
+      "require checks",
+      "merge with receipt"
+    ]
+  },
+  "Z": {
+    "role": "expanded-verified-automation",
+    "authorized": [
+      "repository discovery",
+      "branch creation",
+      "file create/update",
+      "PR creation/update",
+      "workflow inspection",
+      "merge after passing checks"
+    ],
+    "gated": [
+      "repository creation",
+      "visibility changes",
+      "secret access",
+      "public source mirroring",
+      "release publication"
+    ]
+  },
+  "XYZ": {
+    "entry": "X orchestrates Y and Z",
+    "checksRequired": true,
+    "receiptsRequired": true,
+    "rollbackRequired": true
+  }
+}

--- a/examples/norstein-public-bridge.json
+++ b/examples/norstein-public-bridge.json
@@ -1,6 +1,6 @@
 {
-  "schema": "jp.norstein.public-bridge.v1",
-  "bridgeId": "NORSTEIN-PUBLIC-20260711-001",
+  "schema": "jp.norstein.public-bridge.v2",
+  "bridgeId": "NORSTEIN-PUBLIC-20260711-002",
   "owner": "JP / Justin Rackham",
   "publicRepository": "hvitiswift-afk/nextjs-boilerplate",
   "privateCanonicalRepository": "hvitiswift-afk/Norstein-Bekkler",
@@ -25,5 +25,7 @@
     "paymentExecution": false,
     "metaPosting": false,
     "storeSubmission": false
-  }
+  },
+  "connectedGitHubCapability": "GITHUB-YZ-20260711-001",
+  "mode": "XYZ.improved"
 }

--- a/examples/norstein-public-bridge.json
+++ b/examples/norstein-public-bridge.json
@@ -1,0 +1,29 @@
+{
+  "schema": "jp.norstein.public-bridge.v1",
+  "bridgeId": "NORSTEIN-PUBLIC-20260711-001",
+  "owner": "JP / Justin Rackham",
+  "publicRepository": "hvitiswift-afk/nextjs-boilerplate",
+  "privateCanonicalRepository": "hvitiswift-afk/Norstein-Bekkler",
+  "publicUrls": {
+    "nexus": "https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site",
+    "campaign": "https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site/campaign",
+    "authority": "https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site/nexus/entries"
+  },
+  "fundraiser": {
+    "recipient": "Fardarter Gaming LLC",
+    "goalUsd": 1000000,
+    "fundingType": "voluntary-donation",
+    "repayment": false,
+    "paymentProvider": "PayPal"
+  },
+  "publication": {
+    "publicMetadataOnly": true,
+    "privateSourceMirrored": false,
+    "secrets": false,
+    "credentials": false,
+    "donorData": false,
+    "paymentExecution": false,
+    "metaPosting": false,
+    "storeSubmission": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "security:secrets:check": "node scripts/check-secret-boundaries.mjs",
     "vercel:token:check": "node scripts/check-vercel-token-env.mjs",
     "griploom:checks": "npm run security:secrets:check && npm run griploom:id:check && npm run griploom:screenplay:check && npm run griploom:ml:check && npm run griploom:tick:check && npm run griploom:launch:check && npm run griploom:launch:print:check && npm run griploom:science:check && npm run f-wad:check && npm run griploom:checks:index",
-    "griploom:verify": "node scripts/verify-griploom-build.mjs",
-    "norstein:public:check": "node scripts/check-norstein-public-bridge.mjs"
+    "griploom:verify": "node scripts/verify-griploom-build.mjs"
   },
   "dependencies": {
     "next": "15.5.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "security:secrets:check": "node scripts/check-secret-boundaries.mjs",
     "vercel:token:check": "node scripts/check-vercel-token-env.mjs",
     "griploom:checks": "npm run security:secrets:check && npm run griploom:id:check && npm run griploom:screenplay:check && npm run griploom:ml:check && npm run griploom:tick:check && npm run griploom:launch:check && npm run griploom:launch:print:check && npm run griploom:science:check && npm run f-wad:check && npm run griploom:checks:index",
-    "griploom:verify": "node scripts/verify-griploom-build.mjs"
+    "griploom:verify": "node scripts/verify-griploom-build.mjs",
+    "norstein:public:check": "node scripts/check-norstein-public-bridge.mjs"
   },
   "dependencies": {
     "next": "15.5.2",

--- a/scripts/check-norstein-public-bridge.mjs
+++ b/scripts/check-norstein-public-bridge.mjs
@@ -1,0 +1,11 @@
+import {readFile} from "node:fs/promises";
+const b=JSON.parse(await readFile("examples/norstein-public-bridge.json","utf8"));
+const assert=(v,m)=>{if(!v)throw new Error(m)};
+assert(b.schema==="jp.norstein.public-bridge.v1","schema mismatch");
+assert(b.publicRepository==="hvitiswift-afk/nextjs-boilerplate","public repository mismatch");
+assert(b.privateCanonicalRepository==="hvitiswift-afk/Norstein-Bekkler","private canonical identity mismatch");
+assert(Object.values(b.publicUrls).every(u=>u.startsWith("https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site")),"public URL mismatch");
+assert(b.fundraiser.fundingType==="voluntary-donation"&&b.fundraiser.repayment===false,"fundraiser terms changed");
+assert(b.publication.publicMetadataOnly===true&&b.publication.privateSourceMirrored===false,"publication boundary changed");
+for(const key of ["secrets","credentials","donorData","paymentExecution","metaPosting","storeSubmission"])assert(b.publication[key]===false,key+" must remain false");
+console.log(JSON.stringify({verified:true,bridgeId:b.bridgeId,publicRepository:b.publicRepository,privateCanonicalRepository:b.privateCanonicalRepository}));

--- a/scripts/check-norstein-public-bridge.mjs
+++ b/scripts/check-norstein-public-bridge.mjs
@@ -1,11 +1,15 @@
 import {readFile} from "node:fs/promises";
 const b=JSON.parse(await readFile("examples/norstein-public-bridge.json","utf8"));
+const g=JSON.parse(await readFile("examples/norstein-github-capability.json","utf8"));
 const assert=(v,m)=>{if(!v)throw new Error(m)};
-assert(b.schema==="jp.norstein.public-bridge.v1","schema mismatch");
+assert(b.schema==="jp.norstein.public-bridge.v2","bridge schema mismatch");
 assert(b.publicRepository==="hvitiswift-afk/nextjs-boilerplate","public repository mismatch");
 assert(b.privateCanonicalRepository==="hvitiswift-afk/Norstein-Bekkler","private canonical identity mismatch");
 assert(Object.values(b.publicUrls).every(u=>u.startsWith("https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site")),"public URL mismatch");
 assert(b.fundraiser.fundingType==="voluntary-donation"&&b.fundraiser.repayment===false,"fundraiser terms changed");
 assert(b.publication.publicMetadataOnly===true&&b.publication.privateSourceMirrored===false,"publication boundary changed");
 for(const key of ["secrets","credentials","donorData","paymentExecution","metaPosting","storeSubmission"])assert(b.publication[key]===false,key+" must remain false");
-console.log(JSON.stringify({verified:true,bridgeId:b.bridgeId,publicRepository:b.publicRepository,privateCanonicalRepository:b.privateCanonicalRepository}));
+assert(g.schema==="jp.github.capability.yz.v1"&&g.Y.public.visibility==="public"&&g.Y.private.visibility==="private","Y repository roles invalid");
+assert(g.XYZ.checksRequired&&g.XYZ.receiptsRequired&&g.XYZ.rollbackRequired,"XYZ invariant missing");
+assert(g.Z.authorized.includes("merge after passing checks")&&g.Z.gated.includes("secret access"),"Z authority boundary invalid");
+console.log(JSON.stringify({verified:true,bridgeId:b.bridgeId,capabilityId:g.capabilityId,publicRepository:b.publicRepository,privateCanonicalRepository:b.privateCanonicalRepository,mode:"XYZ.improved"}));


### PR DESCRIPTION
## Public + private Norstein rails

Uses this existing public Goblin/GRIPLOOM repository as Norstein's public GitHub rail while preserving `hvitiswift-afk/Norstein-Bekkler` as the private canonical source.

## Added

- public Nexus, campaign, and X-authority links
- machine-readable public/private bridge record
- public-boundary documentation
- automated verifier and GitHub Actions check

## Safety

Only public metadata is included. No private source, secrets, credentials, donor data, payout information, payment execution, Meta posting, or store-submission authority is published.