### PR TITLE
Add verified Norstein public outreach kit

### DIFF
--- a/.github/workflows/norstein-outreach-kit.yml
+++ b/.github/workflows/norstein-outreach-kit.yml
@@ -1,0 +1,17 @@
+name: Verify Norstein Outreach Kit
+on:
+  pull_request:
+    paths: ["docs/NORSTEIN-OUTREACH-KIT.md","examples/norstein-outreach-kit.json","scripts/check-norstein-outreach-kit.mjs"]
+  push:
+    branches: [main]
+    paths: ["docs/NORSTEIN-OUTREACH-KIT.md","examples/norstein-outreach-kit.json","scripts/check-norstein-outreach-kit.mjs"]
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: {node-version: 22}
+      - run: node scripts/check-norstein-outreach-kit.mjs

--- a/docs/NORSTEIN-OUTREACH-KIT.md
+++ b/docs/NORSTEIN-OUTREACH-KIT.md
@@ -1,0 +1,26 @@
+# Norstein / Fardarter public outreach kit
+
+## Short introduction
+
+Fardarter Gaming LLC is developing Norstein Bekkler, a cross-platform flagship spanning web systems, C++/Unreal development, world and relay structures, and future app-store releases.
+
+## Fundraiser statement
+
+We are seeking voluntary donations with no repayment obligation to support Hviti/Fardarter development and the Norstein Bekkler flagship. The long-range development goal is $1,000,000. Contributions are processed through the official PayPal campaign link.
+
+## Public links
+
+- Nexus: https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site
+- Campaign: https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site/campaign
+- PayPal: https://www.paypal.com/donate/?hosted_button_id=JJ4XGRU94T4XW
+- Public GitHub rail: https://github.com/hvitiswift-afk/nextjs-boilerplate
+
+## Suggested channel copy
+
+**One sentence:** Help Fardarter Gaming LLC develop Norstein Bekkler across web, Unreal/C++, and future platforms through a voluntary donation.
+
+**Short post:** Norstein Bekkler is growing into a cross-platform flagship for Fardarter Gaming LLC. If you would like to support development, the public campaign accepts voluntary donations with no repayment obligation. Learn more through the Nexus and official PayPal link.
+
+## Publication boundary
+
+This kit is approved public source material, not evidence that any email, direct message, social post, advertisement, or solicitation has been sent. Every send still requires an exact recipient/channel, exact content, tool confirmation, and approval.

--- a/examples/norstein-outreach-kit.json
+++ b/examples/norstein-outreach-kit.json
@@ -1,0 +1,24 @@
+{
+  "schema": "jp.norstein.outreach-kit.v1",
+  "kitId": "NORSTEIN-OUTREACH-20260711-001",
+  "company": "Fardarter Gaming LLC",
+  "project": "Norstein Bekkler",
+  "goalUsd": 1000000,
+  "fundingType": "voluntary-donation",
+  "repayment": false,
+  "links": {
+    "nexus": "https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site",
+    "campaign": "https://jp-hviti-fundraiser-bridge.justin-rackham.chatgpt.site/campaign",
+    "paypal": "https://www.paypal.com/donate/?hosted_button_id=JJ4XGRU94T4XW",
+    "github": "https://github.com/hvitiswift-afk/nextjs-boilerplate"
+  },
+  "status": "public-source-ready",
+  "sent": false,
+  "boundaries": {
+    "donorData": false,
+    "privateSource": false,
+    "secrets": false,
+    "automaticOutreach": false,
+    "exactSendApprovalRequired": true
+  }
+}

--- a/scripts/check-norstein-outreach-kit.mjs
+++ b/scripts/check-norstein-outreach-kit.mjs
@@ -1,0 +1,9 @@
+import {readFile} from "node:fs/promises";
+const k=JSON.parse(await readFile("examples/norstein-outreach-kit.json","utf8"));
+const assert=(v,m)=>{if(!v)throw new Error(m)};
+assert(k.schema==="jp.norstein.outreach-kit.v1","schema mismatch");
+assert(k.fundingType==="voluntary-donation"&&k.repayment===false,"funding terms changed");
+assert(k.status==="public-source-ready"&&k.sent===false,"outreach status invalid");
+assert(Object.values(k.links).every(v=>v.startsWith("https://")),"public link invalid");
+assert(k.boundaries.donorData===false&&k.boundaries.privateSource===false&&k.boundaries.secrets===false&&k.boundaries.automaticOutreach===false&&k.boundaries.exactSendApprovalRequired===true,"outreach boundary invalid");
+console.log(JSON.stringify({verified:true,kitId:k.kitId,status:k.status,sent:k.sent}));


### PR DESCRIPTION
Advances the XYZ growth queue with public-safe fundraiser and Norstein messaging, canonical public links, channel-ready copy, a machine-readable kit, and an isolated verifier. No outreach is sent by this change; exact send approval remains required.