### PR TITLE
Add reusable Fardarter Pages enablement tool

### DIFF
--- a/.github/workflows/enable-fardarter-pages.yml
+++ b/.github/workflows/enable-fardarter-pages.yml
@@ -1,0 +1,23 @@
+name: Enable Fardarter GitHub Pages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  enable-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable GitHub Pages with workflow builds
+        env:
+          GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/enable-fardarter-pages.mjs
+
+      - name: Record next step
+        run: echo "Pages enabled. Run the Publish Fardarter Startup Site workflow next."

--- a/docs/FARDARTER-PAGES-TOOL.md
+++ b/docs/FARDARTER-PAGES-TOOL.md
@@ -1,0 +1,28 @@
+# Fardarter GitHub Pages Enablement Tool
+
+This tool converts the final repository-setting blocker into a repeatable, receiptable workflow.
+
+## Files
+
+- `scripts/enable-fardarter-pages.mjs`
+- `.github/workflows/enable-fardarter-pages.yml`
+- `.github/workflows/fardarter-pages.yml`
+
+## Required secret
+
+Create a repository Actions secret named `GH_ADMIN_TOKEN` containing a fine-grained GitHub personal access token restricted to this repository with **Administration: Read and write** permission.
+
+Do not commit the token. Do not place it in issues, logs, source files, or workflow inputs.
+
+## Run sequence
+
+1. Add the `GH_ADMIN_TOKEN` repository secret.
+2. Open **Actions → Enable Fardarter GitHub Pages → Run workflow**.
+3. Confirm the run reports `created` or `updated` with `build_type: workflow`.
+4. Run **Publish Fardarter Startup Site**.
+5. Verify `https://hvitiswift-afk.github.io/nextjs-boilerplate/`.
+6. Save the Actions run URL and live URL in issue #102, then close it.
+
+## Boundaries
+
+The tool only configures GitHub Pages for the current repository. It does not register domains, create email accounts, purchase services, submit an OpenAI application, or claim OpenAI affiliation.

--- a/scripts/enable-fardarter-pages.mjs
+++ b/scripts/enable-fardarter-pages.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const token = process.env.GH_ADMIN_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY || 'hvitiswift-afk/nextjs-boilerplate';
+
+if (!token) {
+  console.error('GH_ADMIN_TOKEN is required. Use a fine-grained token with repository Administration write permission.');
+  process.exit(2);
+}
+
+const [owner, repo] = repository.split('/');
+if (!owner || !repo) {
+  console.error(`Invalid repository: ${repository}`);
+  process.exit(2);
+}
+
+const headers = {
+  Accept: 'application/vnd.github+json',
+  Authorization: `Bearer ${token}`,
+  'X-GitHub-Api-Version': '2022-11-28',
+  'Content-Type': 'application/json',
+};
+
+async function request(method, path, body) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  let data = null;
+  try { data = text ? JSON.parse(text) : null; } catch { data = text; }
+  return { response, data };
+}
+
+const pagesPath = `/repos/${owner}/${repo}/pages`;
+let current = await request('GET', pagesPath);
+
+if (current.response.status === 404) {
+  const created = await request('POST', pagesPath, { build_type: 'workflow' });
+  if (!created.response.ok) {
+    console.error('Failed to enable GitHub Pages:', created.response.status, created.data);
+    process.exit(1);
+  }
+  console.log(JSON.stringify({ action: 'created', status: created.response.status, pages: created.data }, null, 2));
+} else if (current.response.ok) {
+  const updated = await request('PUT', pagesPath, { build_type: 'workflow' });
+  if (!updated.response.ok) {
+    console.error('Failed to set GitHub Pages build type:', updated.response.status, updated.data);
+    process.exit(1);
+  }
+  const refreshed = await request('GET', pagesPath);
+  console.log(JSON.stringify({ action: 'updated', status: updated.response.status, pages: refreshed.data }, null, 2));
+} else {
+  console.error('Failed to inspect GitHub Pages:', current.response.status, current.data);
+  process.exit(1);
+}


### PR DESCRIPTION
## X — Tool

Adds a Node.js GitHub API tool that enables repository Pages with `build_type: workflow`.

## Y — Workflow

Adds a manual GitHub Actions workflow that runs the tool using a repository secret named `GH_ADMIN_TOKEN`.

## Z — Receipt and boundaries

Documents the exact token permission, run sequence, expected live URL, receipt path, and safety boundaries.

The token is not included. Running the workflow still requires the repository owner to add a fine-grained token with Administration write permission as an Actions secret.