### PR TITLE
Add Fardarter Pages readiness handoff

### DIFF
--- a/.github/workflows/fardarter-pages-readiness.yml
+++ b/.github/workflows/fardarter-pages-readiness.yml
@@ -1,0 +1,26 @@
+name: Verify Fardarter Pages Readiness
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'config/fardarter-pages-readiness.json'
+      - 'config/fardarter-github-app-manifest.example.json'
+      - 'docs/FARDARTER-GITHUB-APP-PERMISSION-PACKET.md'
+      - 'docs/FARDARTER-OAUTH-CONNECTOR-PACKET.md'
+      - 'scripts/verify-fardarter-pages-readiness.mjs'
+      - '.github/workflows/enable-fardarter-pages.yml'
+      - '.github/workflows/fardarter-pages.yml'
+      - 'fardarter-startup/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify repository-side readiness
+        run: node scripts/verify-fardarter-pages-readiness.mjs

--- a/config/fardarter-pages-readiness.json
+++ b/config/fardarter-pages-readiness.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0",
+  "repository": "hvitiswift-afk/nextjs-boilerplate",
+  "site_path": "fardarter-startup",
+  "expected_live_url": "https://hvitiswift-afk.github.io/nextjs-boilerplate/",
+  "routes": ["github_app", "oauth"],
+  "enable_workflow": ".github/workflows/enable-fardarter-pages.yml",
+  "publish_workflow": ".github/workflows/fardarter-pages.yml",
+  "receipt_issue": 102,
+  "status": "external_authorization_required"
+}

--- a/scripts/verify-fardarter-pages-readiness.mjs
+++ b/scripts/verify-fardarter-pages-readiness.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+
+const requiredFiles = [
+  'config/fardarter-pages-readiness.json',
+  'config/fardarter-github-app-manifest.example.json',
+  'docs/FARDARTER-GITHUB-APP-PERMISSION-PACKET.md',
+  'docs/FARDARTER-OAUTH-CONNECTOR-PACKET.md',
+  '.github/workflows/enable-fardarter-pages.yml',
+  '.github/workflows/fardarter-pages.yml',
+  'fardarter-startup/index.html',
+  'fardarter-startup/privacy.html'
+];
+
+const missing = requiredFiles.filter((file) => !fs.existsSync(file));
+if (missing.length) {
+  console.error(JSON.stringify({ status: 'blocked', missing }, null, 2));
+  process.exit(1);
+}
+
+const readiness = JSON.parse(fs.readFileSync('config/fardarter-pages-readiness.json', 'utf8'));
+const checks = {
+  repository: readiness.repository === 'hvitiswift-afk/nextjs-boilerplate',
+  sitePath: readiness.site_path === 'fardarter-startup',
+  hasAppRoute: readiness.routes?.includes('github_app'),
+  hasOAuthRoute: readiness.routes?.includes('oauth'),
+  hasExpectedUrl: readiness.expected_live_url === 'https://hvitiswift-afk.github.io/nextjs-boilerplate/',
+  receiptIssue: readiness.receipt_issue === 102
+};
+
+const failed = Object.entries(checks).filter(([, ok]) => !ok).map(([name]) => name);
+if (failed.length) {
+  console.error(JSON.stringify({ status: 'blocked', failed }, null, 2));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({
+  status: 'ready_for_external_authorization',
+  repository: readiness.repository,
+  routes: readiness.routes,
+  expectedLiveUrl: readiness.expected_live_url,
+  receiptIssue: readiness.receipt_issue,
+  checkedFiles: requiredFiles.length
+}, null, 2));


### PR DESCRIPTION
Adds a readiness JSON record, validator script, and GitHub Actions check for the Fardarter Pages setup. The files verify that the site, workflows, documentation, expected URL, and issue receipt are aligned. No credentials or external accounts are created by this change.