### PR TITLE
Organize JP Systems Hub and add GitHub operating controls

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,54 @@
+name: JP controlled task
+description: Define a reviewable repository task with boundaries and receipts.
+title: "[Task] "
+body:
+  - type: input
+    id: lane
+    attributes:
+      label: Lane
+      description: Name the affected system or repository lane.
+    validations:
+      required: true
+  - type: textarea
+    id: target
+    attributes:
+      label: Exact target and desired change
+      description: Identify the files, component, workflow, issue, or pull request and the intended result.
+    validations:
+      required: true
+  - type: dropdown
+    id: classification
+    attributes:
+      label: Classification
+      options:
+        - Public-safe
+        - Private canonical
+        - Mixed; boundary review required
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance checks
+      description: List the checks or evidence that will prove completion.
+    validations:
+      required: true
+  - type: textarea
+    id: gate
+    attributes:
+      label: External-action gate
+      description: Identify any settings, secrets, deployment, publication, billing, domain, outreach, submission, payment, or credential action that must remain separately approved.
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback and receipt
+      description: State the rollback path and the receipt that must be preserved.
+    validations:
+      required: true
+  - type: checkboxes
+    id: approval
+    attributes:
+      label: Control confirmation
+      options:
+        - label: I understand that issue creation and repository preparation do not authorize merge or external execution.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Summary
+
+Describe the smallest coherent change in this pull request.
+
+## Lane
+
+Name the affected system or repository lane.
+
+## Scope
+
+- Exact files or components changed:
+- Intended result:
+- Explicit exclusions:
+
+## Public / private boundary
+
+Confirm that no secrets, private records, restricted source, credentials, or unsupported external claims are included.
+
+## Verification
+
+List the commands, checks, screenshots, logs, or receipts used to verify this change.
+
+## Risk and rollback
+
+Describe the main failure modes and the exact rollback or revert path.
+
+## External-action gate
+
+State whether any Pages setting, secret, domain, billing, credential, deployment, submission, outreach, payment, or publication action remains. Repository preparation alone does not authorize those actions.
+
+## Receipt
+
+- Issue or task:
+- Branch:
+- Verification result:
+- Approval state:
+- Merge receipt: pending until merged

--- a/docs/repository/PROJECT-MAP.md
+++ b/docs/repository/PROJECT-MAP.md
@@ -1,0 +1,22 @@
+# JP Systems Hub — Project Map
+
+This repository is a public multi-project systems hub maintained by JP. It contains application code, public-safe documentation, verification scripts, deployment workflows, and bridge records for several related workstreams.
+
+## Project lanes
+
+| System | Purpose | Primary locations | Current status | Public boundary |
+|---|---|---|---|---|
+| Goblin / Lichburn | Next.js application and control-console work | `src/`, root app files, `docs/` | Active | Public code and public-safe concepts |
+| GRIPLOOM | Verification, production, receipt, and evidence rails | `docs/`, `scripts/`, `examples/`, app routes | Active | Public-safe documentation and tooling |
+| F-WAD | Field, campaign, and visualization module | app routes, `docs/`, `examples/` | Experimental | Public-safe concept and implementation |
+| Observer routing | Deterministic observer-route and release checks | `scripts/`, `examples/`, `.github/workflows/` | Active | Public code and receipts |
+| Fardarter | Isolated static startup website | `fardarter-startup/` | Deployment pending verification | Public site package only |
+| Norstein | Public bridge to private canonical work | public bridge docs and records | Active bridge | No private source or credentials |
+
+## Operating rule
+
+Every consequential repository action should move through an issue or exact task, a dedicated branch, a reviewable pull request, verification checks, explicit JP approval, and a durable receipt.
+
+## Canonical separation
+
+The private repository `hvitiswift-afk/Norstein-Bekkler` is the canonical private workspace for Norstein source and internal material. This public repository may contain only approved public-safe bridge outputs and receipts.

--- a/docs/repository/PUBLIC-PRIVATE-BOUNDARY.md
+++ b/docs/repository/PUBLIC-PRIVATE-BOUNDARY.md
@@ -1,0 +1,30 @@
+# Public / Private Boundary
+
+This public repository may contain source code, public-safe documentation, examples, validation scripts, deployment workflows, and receipts that do not expose restricted material.
+
+## Public-safe material
+
+- Approved source code and static assets
+- Public project descriptions and status labels
+- Verification scripts and non-secret configuration
+- Public deployment receipts and workflow URLs
+- Public bridge metadata for privately maintained systems
+- Explicit non-affiliation and uncertainty language
+
+## Private material
+
+The following must not be committed, posted in issues, placed in workflow inputs, or exposed in logs:
+
+- Access tokens, private keys, client secrets, session credentials, or recovery codes
+- Personal financial, donor, customer, employee, medical, housing, or legal records
+- Private canonical Norstein source unless separately approved for publication
+- Unpublished evidence packets or personally identifying records
+- Credentials for GitHub, Vercel, Netlify, OpenAI, payment providers, email, DNS, or other services
+
+## Norstein separation
+
+`hvitiswift-afk/Norstein-Bekkler` is the private canonical workspace. This public repository may contain only approved public-safe bridge outputs. A public bridge must never imply that the complete private source is public or that external deployment, endorsement, funding, or acceptance has occurred without a receipt.
+
+## External-action gate
+
+Repository preparation does not authorize account-level actions. Secrets, Pages settings, domains, billing, OAuth clients, GitHub Apps, submissions, outreach, payments, and publication require an exact target, exact action, support and legality fit, rollback or revocation plan, receipt destination, and JP final approval.

--- a/docs/repository/README-NAVIGATION.md
+++ b/docs/repository/README-NAVIGATION.md
@@ -1,0 +1,35 @@
+# README Navigation Plan
+
+The root `README.md` currently contains substantial technical material for Goblin, GRIPLOOM, F-WAD, deployment, verification, and API examples. This plan preserves that material while establishing a clearer front door.
+
+## Proposed root README order
+
+1. **JP Systems Hub** — one-paragraph repository identity.
+2. **Project map** — links to Goblin / Lichburn, GRIPLOOM, F-WAD, Observer routing, Fardarter, and the public Norstein bridge.
+3. **Status and boundaries** — links to the repository status and public/private boundary documents.
+4. **Quick verification** — local install, development, and repository-owned verification commands.
+5. **Release control** — issue → branch → draft PR → checks → JP approval → merge receipt.
+6. **Project details** — retain the existing technical material below the front-door section or move it into project-specific documents through later reviewed pull requests.
+
+## Front-door copy
+
+```md
+# JP Systems Hub
+
+A public multi-project repository for JP's application code, verification rails, public-safe documentation, deployment workflows, and durable receipts.
+
+## Start here
+
+- [Project map](docs/repository/PROJECT-MAP.md)
+- [Current status](docs/repository/STATUS.md)
+- [Public/private boundary](docs/repository/PUBLIC-PRIVATE-BOUNDARY.md)
+- [Release process](docs/repository/RELEASE-PROCESS.md)
+
+## Operating rule
+
+Consequential work moves through an exact task, dedicated branch, reviewable pull request, verification, JP approval, and a durable receipt. Repository preparation does not authorize account-level settings, credentials, billing, deployment, publication, submissions, outreach, or payments.
+```
+
+## Non-destructive migration rule
+
+Do not remove existing README sections until their replacement locations are confirmed and linked. README restructuring should remain reviewable, reversible, and separate from deployment or account-level actions.

--- a/docs/repository/RELEASE-PROCESS.md
+++ b/docs/repository/RELEASE-PROCESS.md
@@ -1,0 +1,36 @@
+# Release Process
+
+## 1. Intake
+
+Start from an issue or exact task that names the lane, target, desired change, public/private classification, acceptance checks, external-action boundary, rollback, and required receipt.
+
+## 2. Branch
+
+Create a dedicated branch from the current approved base. Do not make unrelated changes on the release branch.
+
+## 3. Draft pull request
+
+Open a draft pull request early. The pull request should state scope, exclusions, verification commands, risks, rollback, and whether any external account action remains.
+
+## 4. Verification
+
+Run the repository-owned checks appropriate to the affected lane. Record failures as failures; do not substitute deployment, billing, or account blockers for code verification results.
+
+## 5. Review gate
+
+Before merge, confirm:
+
+- exact files and diff reviewed
+- public/private boundary preserved
+- no secrets or private records added
+- checks complete or blockers explicitly recorded
+- rollback path understood
+- JP final merge approval received
+
+## 6. Merge receipt
+
+Record the pull request number, merge commit, date, checks, reviewer or approval state, and unresolved external actions.
+
+## 7. External release
+
+Deployment, Pages activation, domain changes, credential creation, billing changes, submissions, outreach, or publication remain separate actions. Each requires its own exact approval and execution receipt.

--- a/docs/repository/STATUS.md
+++ b/docs/repository/STATUS.md
@@ -1,0 +1,31 @@
+# Repository Status
+
+Status labels used in this repository:
+
+- **Active** — current code or documentation with an identified owner and verification path.
+- **Experimental** — exploratory work that is not represented as production-ready.
+- **Blocked** — prepared work waiting on a named external setting, credential, service, or approval.
+- **Superseded** — retained for history but replaced by a newer branch, pull request, or implementation.
+- **Private canonical** — source material maintained outside this public repository.
+
+## Current lanes
+
+| Lane | Status | Evidence boundary | Next controlled action |
+|---|---|---|---|
+| Goblin / Lichburn application | Active | Repository source and build checks | Consolidate standard verification entrypoint |
+| GRIPLOOM rails | Active | Scripts, examples, docs, and receipts | Keep checks under one `verify` command |
+| F-WAD | Experimental | Public-safe route and sample checks | Revalidate before release claims |
+| Observer routing | Active | Deterministic scripts and workflow | Preserve release receipts |
+| Fardarter site package | Blocked | Static package and workflow exist; live Pages state remains unverified | Verify Pages setting and deployment receipt |
+| Norstein public bridge | Active bridge | Public-safe metadata only | Keep private canonical source separate |
+
+## Pull-request hygiene
+
+Every open pull request should be placed into one of four outcomes:
+
+1. Merge after revalidation.
+2. Rebase and repair.
+3. Close as superseded.
+4. Close without merge and preserve the reason.
+
+No open pull request should be treated as current merely because it remains open.


### PR DESCRIPTION
## Summary

Creates the first repository-control layer for the public JP Systems Hub.

## Included

- `docs/repository/PROJECT-MAP.md`
- `docs/repository/STATUS.md`
- `docs/repository/PUBLIC-PRIVATE-BOUNDARY.md`
- `docs/repository/RELEASE-PROCESS.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/ISSUE_TEMPLATE/task.yml`

## Purpose

This change makes the multi-project repository easier to understand and establishes a repeatable issue → branch → draft PR → verification → approval → merge receipt workflow.

## Boundary

This PR does not:

- merge itself
- enable or modify GitHub Pages
- create or expose credentials or secrets
- change billing, domains, DNS, OAuth clients, or GitHub Apps
- deploy or publish a site
- move private Norstein source into the public repository

## README decision

The root README is not replaced in this first commit set because it currently contains substantial project-specific material. A reviewed README consolidation can be added to this branch after confirming what should remain on the front page versus move into project documentation.

## Rollback

Close the draft PR and delete the branch, or revert the six additive file commits. Existing application and deployment files are unchanged.

## Approval state

Approved by JP for preparation and draft-PR creation. Merge remains separately gated pending diff review and JP final merge approval.
