### PR TITLE
Add JP Systems Hub README front-door candidate

### DIFF
--- a/README.front-door.md
+++ b/README.front-door.md
@@ -1,0 +1,30 @@
+# JP Systems Hub
+
+A public multi-project repository for JP's application code, verification rails, public-safe documentation, deployment workflows, and durable receipts.
+
+## Start here
+
+- [Project map](docs/repository/PROJECT-MAP.md)
+- [Current status](docs/repository/STATUS.md)
+- [Public/private boundary](docs/repository/PUBLIC-PRIVATE-BOUNDARY.md)
+- [Release process](docs/repository/RELEASE-PROCESS.md)
+- [README navigation plan](docs/repository/README-NAVIGATION.md)
+
+## Main project lanes
+
+- **Goblin / Lichburn** — Next.js application and control-console work.
+- **GRIPLOOM** — verification, production, evidence, and receipt rails.
+- **F-WAD** — experimental field, campaign, and visualization module.
+- **Observer routing** — deterministic route and release checks.
+- **Fardarter** — isolated static startup package with live Pages state still unverified.
+- **Norstein** — public bridge only; canonical private source remains separate.
+
+## Operating rule
+
+Consequential work moves through an exact task, dedicated branch, reviewable pull request, verification, JP approval, and a durable receipt.
+
+Repository preparation does not authorize account-level settings, credentials, billing, deployment, publication, submissions, outreach, or payments.
+
+## Technical documentation
+
+The existing root `README.md` remains the complete technical body for Goblin, GRIPLOOM, F-WAD, verification, deployment, and API examples. This file is the approved front-door candidate for a later safe prepend or migration after the full root README can be updated without content loss.


### PR DESCRIPTION
## Summary

Adds a concise, reviewable JP Systems Hub front-door candidate at `README.front-door.md`.

## Linked task

Closes #108 only after the root README is safely updated without losing its existing 584-line technical body.

## Scope

- Adds one new root-level Markdown file.
- Links the merged project map, status, public/private boundary, release process, and README navigation plan.
- Summarizes the main repository lanes.
- Preserves the current root `README.md` unchanged.

## Why this is staged

The connected GitHub file action replaces complete file contents and does not provide a safe prepend operation. This draft therefore avoids replacing the long existing README until its full contents can be preserved in one exact update.

## Verification

- Existing `README.md` remains unchanged.
- All linked repository-control documents are present on `main`.
- No secrets, private records, deployment settings, credentials, or unsupported external claims are included.

## External-action gate

No Pages, hosting, deployment, domain, billing, credential, submission, outreach, payment, or publication action is authorized.

## Rollback

Close this pull request or revert the single additive commit.

## Approval state

Prepared under JP's XYZ continuation instruction. Merge remains separately gated.
